### PR TITLE
[feat] #6 - 배너리스트 조회 api 반환 json 수정

### DIFF
--- a/src/main/java/com/napzak/domain/banner/api/controller/BannerController.java
+++ b/src/main/java/com/napzak/domain/banner/api/controller/BannerController.java
@@ -11,6 +11,7 @@ import com.napzak.domain.banner.api.dto.response.BannerResponseList;
 import com.napzak.domain.banner.api.dto.response.HomeBannerResponse;
 import com.napzak.domain.banner.api.exception.BannerSuccessCode;
 import com.napzak.domain.banner.api.service.BannerService;
+import com.napzak.domain.banner.core.entity.enums.BannerType;
 import com.napzak.global.common.exception.dto.SuccessResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -26,7 +27,20 @@ public class BannerController implements BannerApi {
 	@GetMapping("/home")
 	public ResponseEntity<SuccessResponse<BannerResponseList>> getBanners() {
 
-		List<HomeBannerResponse> bannerResponse = bannerService.getAllBanners().stream()
+		List<HomeBannerResponse> topBannerResponse = bannerResponseGenerator(BannerType.TOP);
+		List<HomeBannerResponse> middleBannerResponse = bannerResponseGenerator(BannerType.MIDDLE);
+		List<HomeBannerResponse> bottomBannerResponse = bannerResponseGenerator(BannerType.BOTTOM);
+
+		BannerResponseList response = BannerResponseList.of(topBannerResponse, middleBannerResponse,
+			bottomBannerResponse);
+
+		return ResponseEntity.ok()
+			.body(SuccessResponse.of(BannerSuccessCode.BANNER_GET_SUCCESS, response));
+	}
+
+	private List<HomeBannerResponse> bannerResponseGenerator(BannerType bannerType) {
+
+		return bannerService.getAllBanners(bannerType).stream()
 			.map(banner -> HomeBannerResponse.of(
 				banner.getId(),
 				banner.getPhotoUrl(),
@@ -34,11 +48,6 @@ public class BannerController implements BannerApi {
 				banner.getSequence()
 			))
 			.toList();
-
-		BannerResponseList response = BannerResponseList.of(bannerResponse);
-
-		return ResponseEntity.ok()
-			.body(SuccessResponse.of(BannerSuccessCode.BANNER_GET_SUCCESS, response));
 	}
 
 }

--- a/src/main/java/com/napzak/domain/banner/api/controller/BannerController.java
+++ b/src/main/java/com/napzak/domain/banner/api/controller/BannerController.java
@@ -45,7 +45,8 @@ public class BannerController implements BannerApi {
 				banner.getId(),
 				banner.getPhotoUrl(),
 				banner.getRedirectUrl(),
-				banner.getSequence()
+				banner.getSequence(),
+				banner.getIsExternal()
 			))
 			.toList();
 	}

--- a/src/main/java/com/napzak/domain/banner/api/dto/response/BannerResponseList.java
+++ b/src/main/java/com/napzak/domain/banner/api/dto/response/BannerResponseList.java
@@ -3,11 +3,15 @@ package com.napzak.domain.banner.api.dto.response;
 import java.util.List;
 
 public record BannerResponseList<H>(
-	List<HomeBannerResponse> bannerList
+	List<HomeBannerResponse> TopBannerList,
+	List<HomeBannerResponse> MiddleBannerList,
+	List<HomeBannerResponse> BottomBannerList
 ) {
 	public static BannerResponseList of(
-		List<HomeBannerResponse> bannerList
+		List<HomeBannerResponse> topBannerList,
+		List<HomeBannerResponse> middleBannerList,
+		List<HomeBannerResponse> bottomBannerList
 	) {
-		return new BannerResponseList(bannerList);
+		return new BannerResponseList(topBannerList, middleBannerList, bottomBannerList);
 	}
 }

--- a/src/main/java/com/napzak/domain/banner/api/dto/response/HomeBannerResponse.java
+++ b/src/main/java/com/napzak/domain/banner/api/dto/response/HomeBannerResponse.java
@@ -4,19 +4,22 @@ public record HomeBannerResponse(
 	Long bannerId,
 	String bannerPhoto,
 	String bannerUrl,
-	int bannerSequence
+	int bannerSequence,
+	Boolean isExternal
 ) {
 	public static HomeBannerResponse of(
 		final Long bannerId,
 		final String bannerPhoto,
 		final String bannerUrl,
-		final int bannerSequence
+		final int bannerSequence,
+		final Boolean isExternal
 	) {
 		return new HomeBannerResponse(
 			bannerId,
 			bannerPhoto,
 			bannerUrl,
-			bannerSequence
+			bannerSequence,
+			isExternal
 		);
 	}
 }

--- a/src/main/java/com/napzak/domain/banner/api/service/BannerService.java
+++ b/src/main/java/com/napzak/domain/banner/api/service/BannerService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import com.napzak.domain.banner.core.BannerRetriever;
+import com.napzak.domain.banner.core.entity.enums.BannerType;
 import com.napzak.domain.banner.core.vo.Banner;
 
 import lombok.RequiredArgsConstructor;
@@ -15,8 +16,8 @@ public class BannerService {
 
 	private final BannerRetriever bannerRetriever;
 
-	public List<Banner> getAllBanners() {
+	public List<Banner> getAllBanners(BannerType bannerType) {
 
-		return bannerRetriever.findAllBanners();
+		return bannerRetriever.findAllBanners(bannerType);
 	}
 }

--- a/src/main/java/com/napzak/domain/banner/core/BannerRepository.java
+++ b/src/main/java/com/napzak/domain/banner/core/BannerRepository.java
@@ -1,11 +1,16 @@
 package com.napzak.domain.banner.core;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.napzak.domain.banner.core.entity.BannerEntity;
+import com.napzak.domain.banner.core.entity.enums.BannerType;
 
 @Repository
 public interface BannerRepository extends JpaRepository<BannerEntity, Long> {
+
+	List<BannerEntity> findAllByBannerType(BannerType bannerType);
 
 }

--- a/src/main/java/com/napzak/domain/banner/core/BannerRetriever.java
+++ b/src/main/java/com/napzak/domain/banner/core/BannerRetriever.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import com.napzak.domain.banner.core.entity.BannerEntity;
+import com.napzak.domain.banner.core.entity.enums.BannerType;
 import com.napzak.domain.banner.core.vo.Banner;
 
 import lombok.RequiredArgsConstructor;
@@ -15,9 +16,9 @@ public class BannerRetriever {
 
 	private final BannerRepository bannerRepository;
 
-	public List<Banner> findAllBanners() {
+	public List<Banner> findAllBanners(BannerType bannerType) {
 
-		List<BannerEntity> bannerEntityList = bannerRepository.findAll();
+		List<BannerEntity> bannerEntityList = bannerRepository.findAllByBannerType(bannerType);
 
 		return bannerEntityList.stream()
 			.map(Banner::fromEntity)


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #6

## Work Description ✏️

top, middle, bottom 배너로 나누어서 반환되도록 dto 수정하였습니다. 
배너 타입으로 특정 유형 배너 가져오도록 메서드 수정하였습니다. 
isExternal 필드 추가하여 반환합니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="841" alt="image" src="https://github.com/user-attachments/assets/8b883e24-6008-4403-821e-1fe2a7fc348a" />


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
중간 배너, 하단 배너는 저희가 직접 하나씩 존재하도록 db 관리한다고 알고 있어서 
중간, 하단 배너가 db에 2개 이상 존재할 때 예외는 설정해두지 않았어요 😳😳
