### PR TITLE
[feat] #9 - access token 재발급 api 구현 + 로그아웃 검토

### DIFF
--- a/src/main/java/com/napzak/domain/store/api/controller/StoreApi.java
+++ b/src/main/java/com/napzak/domain/store/api/controller/StoreApi.java
@@ -1,6 +1,7 @@
 package com.napzak.domain.store.api.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import com.napzak.domain.genre.api.dto.response.GenreNameListResponse;
 import com.napzak.domain.store.api.dto.request.GenrePreferenceRequest;
+import com.napzak.domain.store.api.dto.response.AccessTokenGenerateResponse;
 import com.napzak.domain.store.api.dto.response.MyPageResponse;
 import com.napzak.domain.store.api.dto.response.StoreInfoResponse;
 import com.napzak.domain.store.api.dto.response.StoreLoginResponse;
@@ -56,6 +58,19 @@ public interface StoreApi {
 	})
 	@PostMapping("/logout")
 	ResponseEntity<SuccessResponse<Void>> logOut(@CurrentMember Long currentStoreId);
+
+	@Operation(summary = "액세스 토큰 재발급", description = "Refresh Token을 기반으로 Access Token을 재발급받는 API")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "Access Token 재발급 성공",
+			content = @Content(schema = @Schema(implementation = AccessTokenGenerateResponse.class))),
+		@ApiResponse(responseCode = "401", description = "Refresh Token이 유효하지 않음"),
+		@ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없음")
+	})
+	@PostMapping("/refresh-token")
+	ResponseEntity<SuccessResponse<AccessTokenGenerateResponse>> reissue(
+		@Parameter(description = "HttpOnly Cookie에 담긴 Refresh Token", hidden = true)
+		@CookieValue("refreshToken") String refreshToken
+	);
 
 	@Operation(summary = "마이페이지 조회", description = "마이페이지 정보 조회 API")
 	@ApiResponses(value = {

--- a/src/main/java/com/napzak/domain/store/api/exception/StoreSuccessCode.java
+++ b/src/main/java/com/napzak/domain/store/api/exception/StoreSuccessCode.java
@@ -17,6 +17,7 @@ public enum StoreSuccessCode implements BaseSuccessCode {
 	GENRE_PREPERENCE_REGISTER_SUCCESS(HttpStatus.CREATED, "장르 정보 저장 성공"),
 	GET_MYPAGE_INFO_SUCCESS(HttpStatus.OK, "마이페이지 정보 조회 성공"),
 	GET_STORE_INFO_SUCCESS(HttpStatus.OK, "상점 정보 조회 성공"),
+	ACCESS_TOKEN_REISSUE_SUCCESS(HttpStatus.OK, "액세스 토큰 재발급 성공"),
 
 	/*
 	201 Created

--- a/src/main/java/com/napzak/domain/store/api/service/AuthenticationService.java
+++ b/src/main/java/com/napzak/domain/store/api/service/AuthenticationService.java
@@ -86,11 +86,9 @@ public class AuthenticationService {
 		Role role = jwtTokenProvider.getRoleFromJwt(refreshToken);
 		Collection<GrantedAuthority> authorities = List.of(role.toGrantedAuthority());
 
-		String nickname = jwtTokenProvider.getNicknameFromJwt(refreshToken);
-
 		UsernamePasswordAuthenticationToken authenticationToken = createAuthenticationToken(storeId, role, authorities);
-		log.info("Generated new access token for storeId: {}, nickname: {}, role: {}, authorities: {}",
-			storeId, nickname, role.getRoleName(), authorities);
+		log.info("Generated new access token for storeId: {}, role: {}, authorities: {}",
+			storeId, role.getRoleName(), authorities);
 
 		return AccessTokenGenerateResponse.from(jwtTokenProvider.issueAccessToken(authenticationToken));
 	}

--- a/src/main/java/com/napzak/global/auth/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/com/napzak/global/auth/jwt/provider/JwtTokenProvider.java
@@ -39,7 +39,6 @@ public class JwtTokenProvider {
 
 	private static final String STORE_ID = "storeId";
 	private static final String ROLE_KEY = "role";
-	private static final String NICKNAME = "nickname";
 
 	@PostConstruct
 	protected void init() {
@@ -135,13 +134,4 @@ public class JwtTokenProvider {
 		return Keys.hmacShaKeyFor(encodedKey.getBytes());
 	}
 
-	public String getNicknameFromJwt(String token) {
-		Claims claims = getBody(token);
-		String nickname = claims.get(NICKNAME).toString();
-
-		// 로그 추가: nickname 확인
-		log.info("Extracted nickname from JWT: {}", nickname);
-
-		return nickname;
-	}
 }

--- a/src/main/java/com/napzak/global/common/config/SecurityConfig.java
+++ b/src/main/java/com/napzak/global/common/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
 		"/error",
 		"/api/v1/stores/login/**",
 		"/api/v1/onboarding/**",
+		"/api/v1/stores/refresh-token/**",
 		"/"
 	};
 


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #9

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

refresh token을 쿠키에 담아 return하게 하였습니다. 
기존 코드들 활용해 refresh token으로 access token 발급받는 api 작성하였습니다.
예전에 구현해 둔 로그아웃 코드 다시 살펴봤는데, 고치지 않고 써도 될 것 같아요. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

### access token 재발급
<img width="846" alt="image" src="https://github.com/user-attachments/assets/0dce36d1-5e89-4c17-b85b-494b19885c37" />
새로 발급받은 토큰으로 다른 api 정상작동 하는 것 확인하였습니다. 

### 로그아웃
<img width="835" alt="image" src="https://github.com/user-attachments/assets/9f2634da-9786-4814-97e4-7299204dddf4" />

<img width="855" alt="image" src="https://github.com/user-attachments/assets/07c55bd6-b553-4dbe-98f1-dead0a71b6fb" />


로그아웃 정상작동되고, 로그아웃 성공 후 한 번 더 로그아웃 요청 보낼 시 리프레쉬 토큰 삭제되어 로그아웃 불가합니다


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

Response body에 refresh token을 넣으면 보안상 위험하다고 해서.. 기존 작성된 코드대로 쿠키 설정해서 넘기는 게 좋을 것 같아 이렇게 작성했어요.

테스트 할 때 닉네임 null로 비어있으면 JwtTokenProvider에 닉네임을 toString 하는 코드에서 오류가 나고, 또
찾아보니 기존 refresh token에 닉네임을 포함하는 코드같은 경우 nickname이 변경되면 refresh token도 유효하지 않게 된다고 해요. 
닉네임 쉽게 쉽게 바꿀 수 있는 저희 기능 특성 상 그냥 provider claim에 포함하지 않고 pk인 id와 role만으로 refresh token을 구성하는 게 나을 것 같아서, 관련 코드에서 nickname 부분은 아예 빼버렸는데……. 어떻게 생각하세요?? 

