### PR TITLE
[feat] #12 - 마이페이지 정보 조회 api 수정 + 설정 서비스 외부링크 조회 api 구현

### DIFF
--- a/src/main/java/com/napzak/domain/external/core/LinkRepository.java
+++ b/src/main/java/com/napzak/domain/external/core/LinkRepository.java
@@ -1,0 +1,14 @@
+package com.napzak.domain.external.core;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.napzak.domain.external.core.entity.LinkEntity;
+import com.napzak.domain.external.core.entity.enums.LinkType;
+
+@Repository
+public interface LinkRepository extends JpaRepository<LinkEntity, Long> {
+
+	LinkEntity findByType(LinkType linkType);
+
+}

--- a/src/main/java/com/napzak/domain/external/core/LinkRetriever.java
+++ b/src/main/java/com/napzak/domain/external/core/LinkRetriever.java
@@ -1,0 +1,21 @@
+package com.napzak.domain.external.core;
+
+import org.springframework.stereotype.Component;
+
+import com.napzak.domain.external.core.entity.LinkEntity;
+import com.napzak.domain.external.core.entity.enums.LinkType;
+import com.napzak.domain.external.core.vo.Link;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class LinkRetriever {
+
+	private final LinkRepository linkRepository;
+
+	public Link retrieveLinkByLinkType(LinkType linkType){
+		LinkEntity linkEntity = linkRepository.findByType(linkType);
+		return Link.fromEntity(linkEntity);
+	}
+}

--- a/src/main/java/com/napzak/domain/external/core/entity/enums/LinkType.java
+++ b/src/main/java/com/napzak/domain/external/core/entity/enums/LinkType.java
@@ -10,7 +10,8 @@ public enum LinkType {
 	VERSION_INFO("버전 정보"),       // 버전 정보
 	GENRE_REQUEST("장르 추가 요청"),      // 장르 추가 요청
 	CUSTOMER_SUPPORT("고객센터"),
-	;
+	TERM("이용약관"),
+	PRIVACY_POLICY("개인정보 처리방침");
 
 	public final String linkType;
 }

--- a/src/main/java/com/napzak/domain/product/core/ProductRepository.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductRepository.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.napzak.domain.product.core.entity.ProductEntity;
+import com.napzak.domain.product.core.entity.enums.TradeType;
 
 import jakarta.persistence.LockModeType;
 
@@ -39,5 +40,7 @@ public interface ProductRepository extends JpaRepository<ProductEntity, Long>, P
 	Optional<ProductEntity> findById(Long productId);
 
 	boolean existsById(Long productId);
+
+	int countByStoreIdAndTradeType(Long storeId, TradeType tradeType);
 }
 

--- a/src/main/java/com/napzak/domain/product/core/ProductRetriever.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductRetriever.java
@@ -42,6 +42,11 @@ public class ProductRetriever {
 	}
 
 	@Transactional(readOnly = true)
+	public int countProductsByStoreIdAndTradeType(Long storeId, TradeType tradeType) {
+		return productRepository.countByStoreIdAndTradeType(storeId, tradeType);
+	}
+
+	@Transactional(readOnly = true)
 	public List<Product> retrieveProducts(SortOption sortOption, Long cursorProductId, Integer cursorOptionalValue,
 		int size, Boolean isOnSale, Boolean isUnopened, List<Long> genreIds, TradeType tradeType) {
 

--- a/src/main/java/com/napzak/domain/store/api/StoreLinkFacade.java
+++ b/src/main/java/com/napzak/domain/store/api/StoreLinkFacade.java
@@ -1,0 +1,20 @@
+package com.napzak.domain.store.api;
+
+import org.springframework.stereotype.Component;
+
+import com.napzak.domain.external.core.LinkRetriever;
+import com.napzak.domain.external.core.entity.enums.LinkType;
+import com.napzak.domain.external.core.vo.Link;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class StoreLinkFacade {
+
+	private final LinkRetriever linkRetriever;
+
+	public Link findByLinkType(LinkType linkType) {
+		return linkRetriever.retrieveLinkByLinkType(linkType);
+	}
+}

--- a/src/main/java/com/napzak/domain/store/api/StoreProductFacade.java
+++ b/src/main/java/com/napzak/domain/store/api/StoreProductFacade.java
@@ -1,0 +1,19 @@
+package com.napzak.domain.store.api;
+
+import org.springframework.stereotype.Component;
+
+import com.napzak.domain.product.core.ProductRetriever;
+import com.napzak.domain.product.core.entity.enums.TradeType;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class StoreProductFacade {
+
+	private final ProductRetriever productRetriever;
+
+	public int getProductCount(Long storeId, TradeType tradeType) {
+		return productRetriever.countProductsByStoreIdAndTradeType(storeId, tradeType);
+	}
+}

--- a/src/main/java/com/napzak/domain/store/api/controller/StoreController.java
+++ b/src/main/java/com/napzak/domain/store/api/controller/StoreController.java
@@ -15,11 +15,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.napzak.domain.external.core.entity.enums.LinkType;
 import com.napzak.domain.genre.api.dto.response.GenreNameDto;
 import com.napzak.domain.genre.api.dto.response.GenreNameListResponse;
 import com.napzak.domain.genre.api.exception.GenreErrorCode;
 import com.napzak.domain.genre.core.vo.Genre;
+import com.napzak.domain.product.core.entity.enums.TradeType;
 import com.napzak.domain.store.api.StoreGenreFacade;
+import com.napzak.domain.store.api.StoreLinkFacade;
+import com.napzak.domain.store.api.StoreProductFacade;
 import com.napzak.domain.store.api.dto.request.GenrePreferenceRequest;
 import com.napzak.domain.store.api.dto.response.LoginSuccessResponse;
 import com.napzak.domain.store.api.dto.response.MyPageResponse;
@@ -54,6 +58,8 @@ public class StoreController implements StoreApi {
 	private final StoreService storeService;
 	private final StoreGenreFacade storeGenreFacade;
 	private final StoreRegistrationService storeRegistrationService;
+	private final StoreProductFacade storeProductFacade;
+	private final StoreLinkFacade storeLinkFacade;
 
 	@PostMapping("/login")
 	public ResponseEntity<SuccessResponse<StoreLoginResponse>> login(
@@ -90,7 +96,12 @@ public class StoreController implements StoreApi {
 		@CurrentMember final Long currentStoreId
 	) {
 		Store store = storeService.getStore(currentStoreId);
-		MyPageResponse myPageResponse = MyPageResponse.of(store.getId(), store.getNickname(), store.getPhoto());
+		int totalSellCount = storeProductFacade.getProductCount(currentStoreId, TradeType.SELL);
+		int totalBuyCount = storeProductFacade.getProductCount(currentStoreId, TradeType.BUY);
+		String serviceLink = storeLinkFacade.findByLinkType(LinkType.CUSTOMER_SUPPORT).getUrl();
+
+		MyPageResponse myPageResponse = MyPageResponse.of(store.getId(), store.getNickname(), store.getPhoto(),
+			totalSellCount, totalBuyCount, serviceLink);
 		return ResponseEntity.ok().body(SuccessResponse.of(StoreSuccessCode.GET_MYPAGE_INFO_SUCCESS, myPageResponse));
 	}
 

--- a/src/main/java/com/napzak/domain/store/api/controller/StoreController.java
+++ b/src/main/java/com/napzak/domain/store/api/controller/StoreController.java
@@ -27,6 +27,7 @@ import com.napzak.domain.store.api.StoreProductFacade;
 import com.napzak.domain.store.api.dto.request.GenrePreferenceRequest;
 import com.napzak.domain.store.api.dto.response.LoginSuccessResponse;
 import com.napzak.domain.store.api.dto.response.MyPageResponse;
+import com.napzak.domain.store.api.dto.response.SettingLinkResponse;
 import com.napzak.domain.store.api.dto.response.StoreInfoResponse;
 import com.napzak.domain.store.api.dto.response.StoreLoginResponse;
 import com.napzak.domain.store.api.exception.StoreErrorCode;
@@ -105,6 +106,20 @@ public class StoreController implements StoreApi {
 		return ResponseEntity.ok().body(SuccessResponse.of(StoreSuccessCode.GET_MYPAGE_INFO_SUCCESS, myPageResponse));
 	}
 
+	@GetMapping("/mypage/setting")
+	public ResponseEntity<SuccessResponse<SettingLinkResponse>> getSettingLink(
+		@CurrentMember final Long currentStoreId
+	) {
+		String noticeLink = storeLinkFacade.findByLinkType(LinkType.NOTICE).getUrl();
+		String termLink = storeLinkFacade.findByLinkType(LinkType.TERM).getUrl();
+		String privacyPolicyLink = storeLinkFacade.findByLinkType(LinkType.PRIVACY_POLICY).getUrl();
+		String versionInfoLink = storeLinkFacade.findByLinkType(LinkType.VERSION_INFO).getUrl();
+
+		SettingLinkResponse settingLinkResponse = SettingLinkResponse.from(noticeLink, termLink, privacyPolicyLink, versionInfoLink);
+
+		return ResponseEntity.ok().body(SuccessResponse.of(StoreSuccessCode.GET_SETTING_LINK_SUCCESS, settingLinkResponse));
+	}
+
 	@GetMapping("/{storeId}")
 	public ResponseEntity<SuccessResponse<StoreInfoResponse>> getStoreInfo(
 		@PathVariable("storeId") Long OnwerId,
@@ -160,6 +175,7 @@ public class StoreController implements StoreApi {
 		return ResponseEntity.ok()
 			.body(SuccessResponse.of(StoreSuccessCode.GENRE_PREPERENCE_REGISTER_SUCCESS, response));
 	}
+
 
 	private List<GenreNameDto> genrePreferenceResponseGenerator(List<GenrePreference> genreList) {
 

--- a/src/main/java/com/napzak/domain/store/api/dto/response/MyPageResponse.java
+++ b/src/main/java/com/napzak/domain/store/api/dto/response/MyPageResponse.java
@@ -3,13 +3,19 @@ package com.napzak.domain.store.api.dto.response;
 public record MyPageResponse(
 	Long storeId,
 	String storeNickName,
-	String storePhoto
+	String storePhoto,
+	int totalSellCount,
+	int totalBuyCount,
+	String serviceLink
 ) {
 	public static MyPageResponse of(
 		final Long storeId,
 		final String storeNickName,
-		final String storePhoto
+		final String storePhoto,
+		final int totalSellCount,
+		final int totalBuyCount,
+		final String serviceLink
 	) {
-		return new MyPageResponse(storeId, storeNickName, storePhoto);
+		return new MyPageResponse(storeId, storeNickName, storePhoto, totalSellCount, totalBuyCount, serviceLink);
 	}
 }

--- a/src/main/java/com/napzak/domain/store/api/dto/response/SettingLinkResponse.java
+++ b/src/main/java/com/napzak/domain/store/api/dto/response/SettingLinkResponse.java
@@ -1,0 +1,18 @@
+package com.napzak.domain.store.api.dto.response;
+
+public record SettingLinkResponse(
+	String noticeLink,
+	String termLink,
+	String privacyPolicyLink,
+	String versionInfoLink
+) {
+	public static SettingLinkResponse from(
+		String noticeLink,
+		String termLink,
+		String privacyPolicyLink,
+		String versionInfoLink
+	) {
+		return new SettingLinkResponse(noticeLink, termLink, privacyPolicyLink, versionInfoLink);
+	}
+}
+

--- a/src/main/java/com/napzak/domain/store/api/exception/StoreSuccessCode.java
+++ b/src/main/java/com/napzak/domain/store/api/exception/StoreSuccessCode.java
@@ -17,6 +17,7 @@ public enum StoreSuccessCode implements BaseSuccessCode {
 	GENRE_PREPERENCE_REGISTER_SUCCESS(HttpStatus.CREATED, "장르 정보 저장 성공"),
 	GET_MYPAGE_INFO_SUCCESS(HttpStatus.OK, "마이페이지 정보 조회 성공"),
 	GET_STORE_INFO_SUCCESS(HttpStatus.OK, "상점 정보 조회 성공"),
+	GET_SETTING_LINK_SUCCESS(HttpStatus.OK, "설정 링크 조회 성공"),
 
 	/*
 	201 Created


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #12

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 마이페이지 정보 조회 api 수정
판매중(구해요중), 예약중, 거래완료 등 모든 status를 포함한 총 buy, sell 상품 수를 각각 포함하여 반환합니다. 
type이 고객센터인 Link의 url을 포함하여 반환합니다. 

- 설정 서비스 외부링크 조회 api 구현
버전 정보, 공지사항, 개인정보 처리방침, 이용약관 링크를 반환합니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

### 마이페이지 정보 조회 api
<img width="856" alt="image" src="https://github.com/user-attachments/assets/2bd69b77-e254-4adf-adb6-e29747e31e21" />

### 설정 서비스 외부링크 조회 api
<img width="812" alt="image" src="https://github.com/user-attachments/assets/854cf085-8299-4567-a85e-0ae9e2620929" />



## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
