### PR TITLE
[feat] #19 - 상품 상세정보 조회 api 수정 

### DIFF
--- a/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
+++ b/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
@@ -387,7 +387,6 @@ public class ProductController implements ProductApi {
 	) {
 
 		Product product = productService.getProduct(productId);
-		List<Review> reviewList = productReviewFacade.findAllByStoreId(product.getStoreId());
 
 		boolean isInterested = productInterestFacade.getIsInterested(productId, currentStoreId); //좋아요 여부
 		String uploadTime = TimeUtils.calculateUploadTime(product.getCreatedAt()); //업로드 시간
@@ -404,23 +403,24 @@ public class ProductController implements ProductApi {
 
 		StoreStatusDto storeStatus = productStoreFacade.findStoreStatusDtoByStoreId(product.getStoreId());
 
-		List<Long> reviewIds = reviewList.stream()
-			.map(Review::getId)
-			.toList();
-
-		Map<Long, String> reviewerNicknames = productReviewFacade.findReviewerNamesByReviewId(product.getStoreId(),
-			reviewIds);
-
-		List<StoreReviewDto> storeReviewDtoList = reviewList.stream()
-			.map(review -> {
-				String reviewerNickname = reviewerNicknames.get(review.getId());
-				return StoreReviewDto.from(review, reviewerNickname, product);
-			})
-			.toList();
+		// List<Review> reviewList = productReviewFacade.findAllByStoreId(product.getStoreId());
+		//
+		// List<Long> reviewIds = reviewList.stream()
+		// 	.map(Review::getId)
+		// 	.toList();
+		//
+		// Map<Long, String> reviewerNicknames = productReviewFacade.findReviewerNamesByReviewId(product.getStoreId(),
+		// 	reviewIds);
+		//
+		// List<StoreReviewDto> storeReviewDtoList = reviewList.stream()
+		// 	.map(review -> {
+		// 		String reviewerNickname = reviewerNicknames.get(review.getId());
+		// 		return StoreReviewDto.from(review, reviewerNickname, product);
+		// 	})
+		// 	.toList();
 
 		ProductDetailResponse response = new ProductDetailResponse(isInterested, productDetailDto, photoDtoList,
-			storeStatus,
-			storeReviewDtoList);
+			storeStatus);
 
 		return ResponseEntity.ok(
 			SuccessResponse.of(

--- a/src/main/java/com/napzak/domain/product/api/dto/response/ProductDetailDto.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/response/ProductDetailDto.java
@@ -10,7 +10,7 @@ public record ProductDetailDto(
 	String productName,
 	int price,
 	String uploadTime,
-	int viewCount,
+	int chatCount,
 	int interestCount,
 	String description,
 	@JsonInclude(JsonInclude.Include.NON_NULL)
@@ -35,7 +35,7 @@ public record ProductDetailDto(
 			product.getTitle(),
 			product.getPrice(),
 			uploadTime,
-			product.getViewCount(),
+			product.getChatCount(),
 			product.getInterestCount(),
 			product.getDescription(),
 			product.getProductCondition() != null ? product.getProductCondition().toString() : null,

--- a/src/main/java/com/napzak/domain/product/api/dto/response/ProductDetailResponse.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/response/ProductDetailResponse.java
@@ -16,9 +16,6 @@ public record ProductDetailResponse(
 	List<ProductPhotoDto> productPhotoList,
 
 	@JsonProperty("storeInfo")
-	StoreStatusDto storeInfo,
-
-	@JsonProperty("storeReviewList")
-	List<StoreReviewDto> storeReviewList
+	StoreStatusDto storeInfo
 ) {
 }

--- a/src/main/java/com/napzak/domain/store/api/dto/response/StoreStatusDto.java
+++ b/src/main/java/com/napzak/domain/store/api/dto/response/StoreStatusDto.java
@@ -4,16 +4,16 @@ public record StoreStatusDto(
 	Long userId,
 	String storePhoto,
 	String nickname,
-	Long totalProducts,
-	Long totalTransactions
+	Long totalSellCount,
+	Long totalBuyCount
 ) {
 	public static StoreStatusDto from(
 		Long userId,
 		String storePhoto,
 		String nickname,
-		Long totalProducts,
-		Long totalTransactions
+		Long totalSellCount,
+		Long totalBuyCount
 	) {
-		return new StoreStatusDto(userId, storePhoto, nickname, totalProducts, totalTransactions);
+		return new StoreStatusDto(userId, storePhoto, nickname, totalSellCount, totalBuyCount);
 	}
 }

--- a/src/main/java/com/napzak/domain/store/core/StoreRepository.java
+++ b/src/main/java/com/napzak/domain/store/core/StoreRepository.java
@@ -22,9 +22,9 @@ public interface StoreRepository extends JpaRepository<StoreEntity, Long> {
 			s.id,
 			s.photo,
 			s.nickname,
-			COUNT(p.id),
-			SUM(CASE WHEN p.tradeStatus = 'COMPLETED' THEN 1 ELSE 0 END)
-				    )
+			COALESCE(SUM(CASE WHEN p.tradeType = 'SELL' THEN 1 ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN p.tradeType = 'BUY' THEN 1 ELSE 0 END), 0)
+			)
 			FROM StoreEntity s
 			LEFT JOIN ProductEntity p ON s.id = p.storeId
 			WHERE s.id = :storeId


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #19

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
기존 storeInfo가 총 상품갯수, 거래완료 상품 갯수를 반환하던 것을 수정하여 총 팔아요 수, 구해요 수를 반환하도록 하였습니다. 
viewCount 필드를 삭제하였습니다. 
chatCount 필드를 추가하였습니다. 
리뷰 관련 필드를 주석처리하였습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

<img width="852" alt="image" src="https://github.com/user-attachments/assets/2bf9bfd8-ded6-4e21-b066-52baf37f79ff" />

<img width="846" alt="image" src="https://github.com/user-attachments/assets/00302f65-f630-40ac-ad1c-4d60a58fad8e" />


<img width="616" alt="image" src="https://github.com/user-attachments/assets/8fa6934b-9a7b-4f8a-bcb9-416c6968f2f4" />


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
해당 api 노션 명세서 댓글에 '서버 : 조회수, 좋아요수 로직 수정, 리뷰 관련 정보 삭제' 라고 되어있는데, 어떤 좋아요수 로직 수정을 말씀하시는 걸까요? 🥹🥹
