### PR TITLE
[feat] #25 - 장르 검색 api 수정

### DIFF
--- a/src/main/java/com/napzak/domain/genre/api/GenreLinkFacade.java
+++ b/src/main/java/com/napzak/domain/genre/api/GenreLinkFacade.java
@@ -1,0 +1,20 @@
+package com.napzak.domain.genre.api;
+
+import org.springframework.stereotype.Component;
+
+import com.napzak.domain.external.core.LinkRetriever;
+import com.napzak.domain.external.core.entity.enums.LinkType;
+import com.napzak.domain.external.core.vo.Link;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class GenreLinkFacade {
+
+	private final LinkRetriever linkRetriever;
+
+	public Link findByLinkType(LinkType linkType) {
+		return linkRetriever.retrieveLinkByLinkType(linkType);
+	}
+}

--- a/src/main/java/com/napzak/domain/genre/api/controller/GenreController.java
+++ b/src/main/java/com/napzak/domain/genre/api/controller/GenreController.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.napzak.domain.external.core.entity.enums.LinkType;
+import com.napzak.domain.genre.api.GenreLinkFacade;
 import com.napzak.domain.genre.api.dto.response.GenreListResponse;
 import com.napzak.domain.genre.api.dto.response.GenreNameListResponse;
 import com.napzak.domain.genre.api.exception.GenreSuccessCode;
@@ -27,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("api/v1")
 public class GenreController implements GenreApi {
 	private final GenreService genreService;
+	private final GenreLinkFacade genreLinkFacade;
 
 	@Override
 	@GetMapping("/onboarding/genres")
@@ -60,8 +63,18 @@ public class GenreController implements GenreApi {
 
 		GenreListResponse response = GenreListResponse.from(sortOption, pagination);
 
+		boolean isEmpty = response.genreList().isEmpty();
+
+		String genreLink = isEmpty
+			? genreLinkFacade.findByLinkType(LinkType.GENRE_REQUEST).getUrl()
+			: null;
+
+		GenreSuccessCode successCode = isEmpty
+			? GenreSuccessCode.GENRE_SEARCH_NO_RESULT
+			: GenreSuccessCode.GENRE_LIST_SEARCH_SUCCESS;
+
 		return ResponseEntity.ok(
-			SuccessResponse.of(GenreSuccessCode.GENRE_LIST_RETRIEVE_SUCCESS, response)
+			SuccessResponse.of(successCode, response, genreLink)
 		);
 	}
 
@@ -99,8 +112,18 @@ public class GenreController implements GenreApi {
 
 		GenreNameListResponse response = GenreNameListResponse.from(sortOption, pagination);
 
+		boolean isEmpty = response.genreList().isEmpty();
+
+		String genreLink = isEmpty
+			? genreLinkFacade.findByLinkType(LinkType.GENRE_REQUEST).getUrl()
+			: null;
+
+		GenreSuccessCode successCode = isEmpty
+			? GenreSuccessCode.GENRE_SEARCH_NO_RESULT
+			: GenreSuccessCode.GENRE_LIST_SEARCH_SUCCESS;
+
 		return ResponseEntity.ok(
-			SuccessResponse.of(GenreSuccessCode.GENRE_LIST_RETRIEVE_SUCCESS, response)
+			SuccessResponse.of(successCode, response, genreLink)
 		);
 	}
 

--- a/src/main/java/com/napzak/domain/genre/api/exception/GenreSuccessCode.java
+++ b/src/main/java/com/napzak/domain/genre/api/exception/GenreSuccessCode.java
@@ -15,6 +15,7 @@ public enum GenreSuccessCode implements BaseSuccessCode {
 	 */
 	GENRE_LIST_RETRIEVE_SUCCESS(HttpStatus.OK, "장르 목록이 조회되었습니다."),
 	GENRE_LIST_SEARCH_SUCCESS(HttpStatus.OK, "검색된 장르 목록이 조회되었습니다."),
+	GENRE_SEARCH_NO_RESULT(HttpStatus.OK, "검색 결과가 없습니다."),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/napzak/global/common/exception/dto/SuccessResponse.java
+++ b/src/main/java/com/napzak/global/common/exception/dto/SuccessResponse.java
@@ -9,15 +9,21 @@ import com.napzak.global.common.exception.base.BaseSuccessCode;
 public record SuccessResponse<T>(
 	int status,
 	String message,
-	T data
+	T data,
+	String externalLink
 ) {
 	// 성공 응답 (데이터 없음)
 	public static <T> SuccessResponse<T> of(BaseSuccessCode baseSuccessCode) {
-		return new SuccessResponse<>(baseSuccessCode.getHttpStatus().value(), baseSuccessCode.getMessage(), null);
+		return new SuccessResponse<>(baseSuccessCode.getHttpStatus().value(), baseSuccessCode.getMessage(), null, null);
 	}
 
 	// 성공 응답 (데이터 있음)
 	public static <T> SuccessResponse<T> of(BaseSuccessCode baseSuccessCode, T data) {
-		return new SuccessResponse<>(baseSuccessCode.getHttpStatus().value(), baseSuccessCode.getMessage(), data);
+		return new SuccessResponse<>(baseSuccessCode.getHttpStatus().value(), baseSuccessCode.getMessage(), data, null);
+	}
+
+	// 성공 응답 (외부 링크 포함)
+	public static <T> SuccessResponse<T> of(BaseSuccessCode baseSuccessCode, T data, String externalLink) {
+		return new SuccessResponse<>(baseSuccessCode.getHttpStatus().value(), baseSuccessCode.getMessage(), data, externalLink);
 	}
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #25 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
장르 검색 시 검색 결과가 없으면 외부링크를 반환하도록 기존 api를 수정했습니다.
외부링크의 경우 장르 리스트 data와 직접적인 비즈니스 관계가 없고 응답 맥락에 따른 유도용 정보임으로 SuccessResponse에 포함시키는데 역할과 책임 분리에 부합한다고 생각해 SuccessResponse를 추가했습니다.
76147b342bb2f7efec9c1f547183a50c695b8809

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="731" alt="image" src="https://github.com/user-attachments/assets/ccd0338b-ab34-4d27-ba8e-12ddcc675c52" />
검색 결과가 존재할 경우 externalLink는 반환되지 않습니다.

<img width="737" alt="image" src="https://github.com/user-attachments/assets/c8aad87d-468f-4f7e-8edb-c13ee8eeb94d" />
검색 결과가 존재하지 않을 경우에만 externalLink가 반환됩니다.

<img width="723" alt="image" src="https://github.com/user-attachments/assets/7fbca950-6f90-4b86-bf24-38bedbea2297" />
<img width="729" alt="image" src="https://github.com/user-attachments/assets/e09fca88-2f65-4239-b260-3eba44bd8808" />
온보딩 장르 검색 시에도 마찬가지로 구현했습니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
