### PR TITLE
[feat] #18 - 상품 삭제, 수정을 위한 상품 조회, 상품 수정 api 구현

### DIFF
--- a/src/main/java/com/napzak/domain/product/api/annotation/SequenceValidator.java
+++ b/src/main/java/com/napzak/domain/product/api/annotation/SequenceValidator.java
@@ -6,18 +6,30 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import com.napzak.domain.product.api.dto.request.ProductPhotoBase;
 import com.napzak.domain.product.api.dto.request.ProductPhotoRequestDto;
 
-public class SequenceValidator implements ConstraintValidator<ValidSequence, List<ProductPhotoRequestDto>> {
+public class SequenceValidator implements ConstraintValidator<ValidSequence, List<?>> {
 
 	@Override
-	public boolean isValid(List<ProductPhotoRequestDto> productPhotoList, ConstraintValidatorContext context) {
-		if (productPhotoList == null || productPhotoList.isEmpty()) {
+	public boolean isValid(List<?> value, ConstraintValidatorContext context) {
+		if (value == null || value.isEmpty()) {
 			return false; // 빈 리스트는 유효하지 않음
 		}
 
+		// ProductPhotoBase 타입인지 확인
+		if (!(value.get(0) instanceof ProductPhotoBase)) {
+			return false;
+		}
+
+		List<ProductPhotoBase> productPhotoList = value.stream()
+			.filter(ProductPhotoBase.class::isInstance)
+			.map(ProductPhotoBase.class::cast)
+			.toList();
+
+
 		List<Integer> sequenceList = productPhotoList.stream()
-			.map(ProductPhotoRequestDto::sequence)
+			.map(ProductPhotoBase::sequence)
 			.toList();
 
 		// 중복 체크

--- a/src/main/java/com/napzak/domain/product/api/controller/ProductApi.java
+++ b/src/main/java/com/napzak/domain/product/api/controller/ProductApi.java
@@ -180,7 +180,7 @@ public interface ProductApi {
 		@PathVariable("productId") Long productId
 	);
 
-	@Operation(summary = "수정을 위한 상품 정보 조회", description = "상품 수정을 위한 상품 정보를 조회합니다.")
+	@Operation(summary = "수정을 위한 팔아요 상품 정보 조회", description = "상품 수정을 위한 팔아요 상품 정보를 조회합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "상품 거래 상태 수정 성공"),
 		@ApiResponse(responseCode = "403", description = "상품 소유자가 아닙니다."),
@@ -188,6 +188,18 @@ public interface ProductApi {
 	})
 	@DeleteMapping("/sell/modify/{productId}")
 	ResponseEntity<SuccessResponse<ProductSellModifyResponse>> getSellProductForModify(
+		@CurrentMember Long currentStoreId,
+		@PathVariable("productId") Long productId
+	);
+
+	@Operation(summary = "수정을 위한 구해요 상품 정보 조회", description = "상품 수정을 위한 구해요 상품 정보를 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "상품 거래 상태 수정 성공"),
+		@ApiResponse(responseCode = "403", description = "상품 소유자가 아닙니다."),
+		@ApiResponse(responseCode = "404", description = "상품을 찾을 수 없습니다.")
+	})
+	@DeleteMapping("/buy/modify/{productId}")
+	ResponseEntity<SuccessResponse<ProductBuyModifyResponse>> getBuyProductForModify(
 		@CurrentMember Long currentStoreId,
 		@PathVariable("productId") Long productId
 	);

--- a/src/main/java/com/napzak/domain/product/api/controller/ProductApi.java
+++ b/src/main/java/com/napzak/domain/product/api/controller/ProductApi.java
@@ -168,6 +168,19 @@ public interface ProductApi {
 		@Valid @RequestBody TradeStatusRequest tradeStatusRequest
 	);
 
+	@Operation(summary = "상품 삭제", description = "상품 데이터를 삭제합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "상품 거래 상태 수정 성공"),
+		@ApiResponse(responseCode = "403", description = "상품 소유자가 아닙니다."),
+		@ApiResponse(responseCode = "404", description = "상품을 찾을 수 없습니다.")
+	})
+	@DeleteMapping("/{productId}")
+	ResponseEntity<SuccessResponse<Void>> deleteProduct(
+		@CurrentMember Long currentStoreId,
+		@PathVariable("productId") Long productId
+	);
+
+
 	@Operation(summary = "추천 상품 조회", description = "사용자의 관심 기반 추천 상품 조회")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "사용자의 관심 기반 추천 상품 조회 성공"),

--- a/src/main/java/com/napzak/domain/product/api/controller/ProductApi.java
+++ b/src/main/java/com/napzak/domain/product/api/controller/ProductApi.java
@@ -180,6 +180,18 @@ public interface ProductApi {
 		@PathVariable("productId") Long productId
 	);
 
+	@Operation(summary = "수정을 위한 상품 정보 조회", description = "상품 수정을 위한 상품 정보를 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "상품 거래 상태 수정 성공"),
+		@ApiResponse(responseCode = "403", description = "상품 소유자가 아닙니다."),
+		@ApiResponse(responseCode = "404", description = "상품을 찾을 수 없습니다.")
+	})
+	@DeleteMapping("/sell/modify/{productId}")
+	ResponseEntity<SuccessResponse<ProductSellModifyResponse>> getSellProductForModify(
+		@CurrentMember Long currentStoreId,
+		@PathVariable("productId") Long productId
+	);
+
 
 	@Operation(summary = "추천 상품 조회", description = "사용자의 관심 기반 추천 상품 조회")
 	@ApiResponses(value = {

--- a/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
+++ b/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
@@ -493,6 +493,47 @@ public class ProductController implements ProductApi {
 			.body(SuccessResponse.of(ProductSuccessCode.PRODUCT_RETRIEVE_SUCCESS, productSellModifyresponse));
 	}
 
+	@PatchMapping("/sell/modify/{productId}")
+	public ResponseEntity<SuccessResponse<ProductSellResponse>> modifySellProduct(
+		@CurrentMember Long currentStoreId,
+		@PathVariable Long productId,
+		@Valid @RequestBody ProductSellCreateRequest productSellCreateRequest
+	) {
+		Product product = productService.getProduct(productId);
+		authChecker(currentStoreId, product);
+
+		product = productService.updateSellProduct(
+			productId,
+			productSellCreateRequest.title(),
+			productSellCreateRequest.description(),
+			productSellCreateRequest.price(),
+			productSellCreateRequest.isDeliveryIncluded(),
+			productSellCreateRequest.standardDeliveryFee(),
+			productSellCreateRequest.halfDeliveryFee(),
+			productSellCreateRequest.productCondition(),
+			productSellCreateRequest.genreId()
+		);
+
+		Map<Integer, String> photoData = productSellCreateRequest.productPhotoList().stream()
+			.collect(Collectors.toMap(
+				ProductPhotoRequestDto::sequence,
+				ProductPhotoRequestDto::photoUrl,
+				(existing, replacement) -> existing,  // 중복 키가 발생하면 기존 값 유지
+				LinkedHashMap::new  // 순서 유지
+			));
+
+		List<ProductPhoto> productPhotoList = productService.updateProductPhotos(product.getId(), photoData);
+
+		ProductSellResponse response = ProductSellResponse.from(product, productPhotoList);
+
+		return ResponseEntity.ok(
+			SuccessResponse.of(
+				ProductSuccessCode.PRODUCT_MODIFY_SUCCESS,
+				response
+			)
+		);
+	}
+
 	@Override
 	@GetMapping("/buy/modify/{productId}")
 	public ResponseEntity<SuccessResponse<ProductBuyModifyResponse>> getBuyProductForModify(
@@ -515,6 +556,44 @@ public class ProductController implements ProductApi {
 
 		return ResponseEntity.ok()
 			.body(SuccessResponse.of(ProductSuccessCode.PRODUCT_RETRIEVE_SUCCESS, productBuyModifyResponse));
+	}
+
+	@PatchMapping("/buy/modify/{productId}")
+	public ResponseEntity<SuccessResponse<ProductBuyResponse>> modifyBuyProduct(
+		@CurrentMember Long currentStoreId,
+		@PathVariable Long productId,
+		@Valid @RequestBody ProductBuyCreateRequest productBuyCreateRequest
+	) {
+		Product product = productService.getProduct(productId);
+		authChecker(currentStoreId, product);
+
+		product = productService.updateBuyProduct(
+			productId,
+			productBuyCreateRequest.title(),
+			productBuyCreateRequest.description(),
+			productBuyCreateRequest.price(),
+			productBuyCreateRequest.isPriceNegotiable(),
+			productBuyCreateRequest.genreId()
+		);
+
+		Map<Integer, String> photoData = productBuyCreateRequest.productPhotoList().stream()
+			.collect(Collectors.toMap(
+				ProductPhotoRequestDto::sequence,
+				ProductPhotoRequestDto::photoUrl,
+				(existing, replacement) -> existing,  // 중복 키가 발생하면 기존 값 유지
+				LinkedHashMap::new  // 순서 유지
+			));
+
+		List<ProductPhoto> productPhotoList = productService.updateProductPhotos(product.getId(), photoData);
+
+		ProductBuyResponse response = ProductBuyResponse.from(product, productPhotoList);
+
+		return ResponseEntity.ok(
+			SuccessResponse.of(
+				ProductSuccessCode.PRODUCT_MODIFY_SUCCESS,
+				response
+			)
+		);
 	}
 
 	@Override

--- a/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
+++ b/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
@@ -29,6 +29,7 @@ import com.napzak.domain.product.api.dto.request.cursor.LowPriceCursor;
 import com.napzak.domain.product.api.dto.request.cursor.PopularCursor;
 import com.napzak.domain.product.api.dto.request.cursor.RecentCursor;
 import com.napzak.domain.product.api.dto.response.ProductBuyListResponse;
+import com.napzak.domain.product.api.dto.response.ProductBuyModifyResponse;
 import com.napzak.domain.product.api.dto.response.ProductBuyResponse;
 import com.napzak.domain.product.api.dto.response.ProductChatResponse;
 import com.napzak.domain.product.api.dto.response.ProductDetailDto;
@@ -492,6 +493,29 @@ public class ProductController implements ProductApi {
 			.body(SuccessResponse.of(ProductSuccessCode.PRODUCT_RETRIEVE_SUCCESS, productSellModifyresponse));
 	}
 
+	@Override
+	@GetMapping("/buy/modify/{productId}")
+	public ResponseEntity<SuccessResponse<ProductBuyModifyResponse>> getBuyProductForModify(
+		@CurrentMember Long currentStoreId,
+		@PathVariable Long productId
+	) {
+		Product product = productService.getProduct(productId);
+		authChecker(currentStoreId, product);
+
+		String genreName = productGenreFacade.getGenreName(product.getGenreId());
+
+		List<ProductPhotoDto> photoDtoList = productService.getProductPhotos(productId).stream()
+			.map(ProductPhotoDto::from)
+			.toList();
+
+		ProductBuyModifyResponse productBuyModifyResponse = ProductBuyModifyResponse.from(
+			product.getId(), genreName, product.getTitle(), product.getDescription(), product.getPrice(),
+			product.getIsPriceNegotiable(), photoDtoList
+		);
+
+		return ResponseEntity.ok()
+			.body(SuccessResponse.of(ProductSuccessCode.PRODUCT_RETRIEVE_SUCCESS, productBuyModifyResponse));
+	}
 
 	@Override
 	@GetMapping("/home/recommend")

--- a/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
+++ b/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
@@ -21,8 +21,10 @@ import com.napzak.domain.product.api.ProductInterestFacade;
 import com.napzak.domain.product.api.ProductReviewFacade;
 import com.napzak.domain.product.api.ProductStoreFacade;
 import com.napzak.domain.product.api.dto.request.ProductBuyCreateRequest;
+import com.napzak.domain.product.api.dto.request.ProductBuyModifyRequest;
 import com.napzak.domain.product.api.dto.request.ProductPhotoRequestDto;
 import com.napzak.domain.product.api.dto.request.ProductSellCreateRequest;
+import com.napzak.domain.product.api.dto.request.ProductSellModifyRequest;
 import com.napzak.domain.product.api.dto.request.TradeStatusRequest;
 import com.napzak.domain.product.api.dto.request.cursor.HighPriceCursor;
 import com.napzak.domain.product.api.dto.request.cursor.LowPriceCursor;
@@ -497,32 +499,24 @@ public class ProductController implements ProductApi {
 	public ResponseEntity<SuccessResponse<ProductSellResponse>> modifySellProduct(
 		@CurrentMember Long currentStoreId,
 		@PathVariable Long productId,
-		@Valid @RequestBody ProductSellCreateRequest productSellCreateRequest
+		@Valid @RequestBody ProductSellModifyRequest productSellModifyRequest
 	) {
 		Product product = productService.getProduct(productId);
 		authChecker(currentStoreId, product);
 
 		product = productService.updateSellProduct(
 			productId,
-			productSellCreateRequest.title(),
-			productSellCreateRequest.description(),
-			productSellCreateRequest.price(),
-			productSellCreateRequest.isDeliveryIncluded(),
-			productSellCreateRequest.standardDeliveryFee(),
-			productSellCreateRequest.halfDeliveryFee(),
-			productSellCreateRequest.productCondition(),
-			productSellCreateRequest.genreId()
+			productSellModifyRequest.title(),
+			productSellModifyRequest.description(),
+			productSellModifyRequest.price(),
+			productSellModifyRequest.isDeliveryIncluded(),
+			productSellModifyRequest.standardDeliveryFee(),
+			productSellModifyRequest.halfDeliveryFee(),
+			productSellModifyRequest.productCondition(),
+			productSellModifyRequest.genreId()
 		);
 
-		Map<Integer, String> photoData = productSellCreateRequest.productPhotoList().stream()
-			.collect(Collectors.toMap(
-				ProductPhotoRequestDto::sequence,
-				ProductPhotoRequestDto::photoUrl,
-				(existing, replacement) -> existing,  // 중복 키가 발생하면 기존 값 유지
-				LinkedHashMap::new  // 순서 유지
-			));
-
-		List<ProductPhoto> productPhotoList = productService.updateProductPhotos(product.getId(), photoData);
+		List<ProductPhoto> productPhotoList = productService.modifyProductPhotos(product.getId(), productSellModifyRequest.productPhotoList());
 
 		ProductSellResponse response = ProductSellResponse.from(product, productPhotoList);
 
@@ -562,29 +556,21 @@ public class ProductController implements ProductApi {
 	public ResponseEntity<SuccessResponse<ProductBuyResponse>> modifyBuyProduct(
 		@CurrentMember Long currentStoreId,
 		@PathVariable Long productId,
-		@Valid @RequestBody ProductBuyCreateRequest productBuyCreateRequest
+		@Valid @RequestBody ProductBuyModifyRequest productBuyModifyRequest
 	) {
 		Product product = productService.getProduct(productId);
 		authChecker(currentStoreId, product);
 
 		product = productService.updateBuyProduct(
 			productId,
-			productBuyCreateRequest.title(),
-			productBuyCreateRequest.description(),
-			productBuyCreateRequest.price(),
-			productBuyCreateRequest.isPriceNegotiable(),
-			productBuyCreateRequest.genreId()
+			productBuyModifyRequest.title(),
+			productBuyModifyRequest.description(),
+			productBuyModifyRequest.price(),
+			productBuyModifyRequest.isPriceNegotiable(),
+			productBuyModifyRequest.genreId()
 		);
 
-		Map<Integer, String> photoData = productBuyCreateRequest.productPhotoList().stream()
-			.collect(Collectors.toMap(
-				ProductPhotoRequestDto::sequence,
-				ProductPhotoRequestDto::photoUrl,
-				(existing, replacement) -> existing,  // 중복 키가 발생하면 기존 값 유지
-				LinkedHashMap::new  // 순서 유지
-			));
-
-		List<ProductPhoto> productPhotoList = productService.updateProductPhotos(product.getId(), photoData);
+		List<ProductPhoto> productPhotoList = productService.modifyProductPhotos(product.getId(), productBuyModifyRequest.productPhotoList());
 
 		ProductBuyResponse response = ProductBuyResponse.from(product, productPhotoList);
 

--- a/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
+++ b/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -452,6 +453,26 @@ public class ProductController implements ProductApi {
 		return ResponseEntity.ok()
 			.body(SuccessResponse.of(ProductSuccessCode.PRODUCT_UPDATE_SUCCESS));
 	}
+
+	@Override
+	@DeleteMapping("{productId}")
+	public ResponseEntity<SuccessResponse<Void>> deleteProduct(
+		@CurrentMember Long currentStoreId,
+		@PathVariable Long productId
+	) {
+
+		Product product = productService.getProduct(productId);
+
+		if (!product.getStoreId().equals(currentStoreId)) {
+			throw new NapzakException((ProductErrorCode.ACCESS_DENIED));
+		}
+
+		productService.deleteProduct(productId);
+
+		return ResponseEntity.ok()
+			.body(SuccessResponse.of(ProductSuccessCode.PRODUCT_DELETE_SUCCESS));
+	}
+
 
 	@Override
 	@GetMapping("/home/recommend")

--- a/src/main/java/com/napzak/domain/product/api/dto/request/ProductBuyModifyRequest.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/request/ProductBuyModifyRequest.java
@@ -1,0 +1,37 @@
+package com.napzak.domain.product.api.dto.request;
+
+import java.util.List;
+
+import com.napzak.domain.product.api.annotation.ValidSequence;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+public record ProductBuyModifyRequest (
+	@NotNull
+	@Size(min = 1, max =10, message = "사진은 최소 1개 이상, 최대 10개까지 등록할 수 있습니다.")
+	@Valid
+	@ValidSequence
+	List<ProductPhotoModifyDto> productPhotoList,
+
+	@NotNull
+	long genreId,
+
+	@NotBlank
+	@Size(max = 50, message = "상품 제목은 50자를 초과할 수 없습니다.")
+	String title,
+
+	@NotBlank
+	@Size(max = 250, message = "상품 설명은 250자를 초과할 수 없습니다.")
+	String description,
+
+	@NotNull
+	@Positive(message = "가격은 0보다 커야합니다.")
+	int price,
+
+	boolean isPriceNegotiable
+) {
+}

--- a/src/main/java/com/napzak/domain/product/api/dto/request/ProductPhotoBase.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/request/ProductPhotoBase.java
@@ -1,0 +1,5 @@
+package com.napzak.domain.product.api.dto.request;
+
+public interface ProductPhotoBase{
+	int sequence();
+}

--- a/src/main/java/com/napzak/domain/product/api/dto/request/ProductPhotoModifyDto.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/request/ProductPhotoModifyDto.java
@@ -1,0 +1,16 @@
+package com.napzak.domain.product.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
+public record ProductPhotoModifyDto(
+	Long photoId,
+
+	@NotBlank(message = "사진 URL은 비어 있을 수 없습니다.")
+	String photoUrl,
+
+	@Positive(message = "사진 순서는 1 이상이어야 합니다.")
+	int sequence
+) implements ProductPhotoBase {
+	@Override public int sequence() { return sequence;}
+}

--- a/src/main/java/com/napzak/domain/product/api/dto/request/ProductPhotoRequestDto.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/request/ProductPhotoRequestDto.java
@@ -9,5 +9,9 @@ public record ProductPhotoRequestDto(
 
 	@Positive(message = "사진 순서는 1 이상이어야 합니다.")
 	int sequence
-) {
+) implements ProductPhotoBase {
+	@Override
+	public int sequence() {
+		return sequence;
+	}
 }

--- a/src/main/java/com/napzak/domain/product/api/dto/request/ProductSellModifyRequest.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/request/ProductSellModifyRequest.java
@@ -1,0 +1,52 @@
+package com.napzak.domain.product.api.dto.request;
+
+import java.util.List;
+
+import com.napzak.domain.product.api.annotation.ValidSequence;
+import com.napzak.domain.product.core.entity.enums.ProductCondition;
+import com.napzak.global.common.annotation.ValidEnum;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+public record ProductSellModifyRequest(
+	@NotNull
+	@Size(min = 1, max =10, message = "사진은 최소 1개 이상, 최대 10개까지 등록할 수 있습니다.")
+	@Valid
+	@ValidSequence
+	List<ProductPhotoModifyDto> productPhotoList,
+
+	@NotNull
+	long genreId,
+
+	@NotBlank(message = "상품 제목을 입력해 주세요.")
+	@Size(max = 50, message = "상품 제목은 50자를 초과할 수 없습니다.")
+	String title,
+
+	@NotBlank(message = "상품 설명을 입력해 주세요.")
+	@Size(max = 250, message = "상품 설명은 250자를 초과할 수 없습니다.")
+	String description,
+
+	@NotNull
+	@ValidEnum(enumClass = ProductCondition.class, message = "유효하지 않은 상품 상태입니다.")
+	ProductCondition productCondition,
+
+	@NotNull
+	@Positive(message = "가격은 0보다 커야합니다.")
+	int price,
+
+	boolean isDeliveryIncluded,
+
+	@NotNull
+	@PositiveOrZero(message = "일반배송비는 0 이상이어야 합니다.")
+	int standardDeliveryFee,
+
+	@NotNull
+	@PositiveOrZero(message = "반값배송비는 0 이상이어야 합니다.")
+	int halfDeliveryFee
+) {
+}

--- a/src/main/java/com/napzak/domain/product/api/dto/response/ProductBuyModifyResponse.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/response/ProductBuyModifyResponse.java
@@ -1,0 +1,26 @@
+package com.napzak.domain.product.api.dto.response;
+
+import java.util.List;
+
+public record ProductBuyModifyResponse(
+	Long productId,
+	String genreName,
+	String title,
+	String description,
+	int price,
+	boolean isPriceNegotiable,
+	List<ProductPhotoDto> productPhotoList
+) {
+	public static ProductBuyModifyResponse from(
+		Long productId,
+		String genreName,
+		String title,
+		String description,
+		int price,
+		boolean isPriceNegotiable,
+		List<ProductPhotoDto> productPhotoList
+	) {
+		return new ProductBuyModifyResponse(productId, genreName, title, description, price, isPriceNegotiable,
+			productPhotoList);
+	}
+}

--- a/src/main/java/com/napzak/domain/product/api/dto/response/ProductBuyResponse.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/response/ProductBuyResponse.java
@@ -3,6 +3,7 @@ package com.napzak.domain.product.api.dto.response;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.napzak.domain.product.core.vo.Product;
 import com.napzak.domain.product.core.vo.ProductPhoto;
 
@@ -14,7 +15,9 @@ public record ProductBuyResponse(
 	String description,
 	int price,
 	boolean isPriceNegotiable,
-	LocalDateTime createdAt
+	LocalDateTime createdAt,
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	LocalDateTime updatedAt
 ) {
 	public static ProductBuyResponse from(Product product, List<ProductPhoto> photos) {
 		List<ProductPhotoResponseDto> productPhotoResponseDtos = photos.stream()
@@ -28,7 +31,8 @@ public record ProductBuyResponse(
 			product.getDescription(),
 			product.getPrice(),
 			product.getIsPriceNegotiable(),
-			product.getCreatedAt()
+			product.getCreatedAt(),
+			product.getUpdatedAt()
 		);
 	}
 }

--- a/src/main/java/com/napzak/domain/product/api/dto/response/ProductBuyResponse.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/response/ProductBuyResponse.java
@@ -16,7 +16,6 @@ public record ProductBuyResponse(
 	int price,
 	boolean isPriceNegotiable,
 	LocalDateTime createdAt,
-	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
 	LocalDateTime updatedAt
 ) {
 	public static ProductBuyResponse from(Product product, List<ProductPhoto> photos) {

--- a/src/main/java/com/napzak/domain/product/api/dto/response/ProductSellModifyResponse.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/response/ProductSellModifyResponse.java
@@ -1,0 +1,34 @@
+package com.napzak.domain.product.api.dto.response;
+
+import java.util.List;
+
+import com.napzak.domain.product.core.entity.enums.ProductCondition;
+
+public record ProductSellModifyResponse(
+	Long productId,
+	String genreName,
+	String title,
+	String description,
+	ProductCondition productCondition,
+	int price,
+	boolean isDeliveryIncluded,
+	int standardDeliveryFee,
+	int halfDeliveryFee,
+	List<ProductPhotoDto> productPhotoList
+) {
+	public static ProductSellModifyResponse from(
+		Long productId,
+		String genreName,
+		String title,
+		String description,
+		ProductCondition productCondition,
+		int price,
+		boolean isDeliveryIncluded,
+		int standardDeliveryFee,
+		int halfDeliveryFee,
+		List<ProductPhotoDto> productPhotoList
+	) {
+		return new ProductSellModifyResponse(productId, genreName, title, description, productCondition, price,
+			isDeliveryIncluded, standardDeliveryFee, halfDeliveryFee, productPhotoList);
+	}
+}

--- a/src/main/java/com/napzak/domain/product/api/dto/response/ProductSellResponse.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/response/ProductSellResponse.java
@@ -3,6 +3,7 @@ package com.napzak.domain.product.api.dto.response;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.napzak.domain.product.core.entity.enums.ProductCondition;
 import com.napzak.domain.product.core.vo.Product;
 import com.napzak.domain.product.core.vo.ProductPhoto;
@@ -18,7 +19,9 @@ public record ProductSellResponse(
 	boolean isDeliveryIncluded,
 	int standardDeliveryFee,
 	int halfDeliveryFee,
-	LocalDateTime createdAt
+	LocalDateTime createdAt,
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	LocalDateTime updatedAt
 ) {
 	public static ProductSellResponse from(Product product, List<ProductPhoto> photos) {
 		List<ProductPhotoResponseDto> productPhotoResponseDtos = photos.stream()
@@ -35,7 +38,8 @@ public record ProductSellResponse(
 			product.getIsDeliveryIncluded(),
 			product.getStandardDeliveryFee(),
 			product.getHalfDeliveryFee(),
-			product.getCreatedAt()
+			product.getCreatedAt(),
+			product.getUpdatedAt()
 		);
 	}
 }

--- a/src/main/java/com/napzak/domain/product/api/dto/response/ProductSellResponse.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/response/ProductSellResponse.java
@@ -20,7 +20,6 @@ public record ProductSellResponse(
 	int standardDeliveryFee,
 	int halfDeliveryFee,
 	LocalDateTime createdAt,
-	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
 	LocalDateTime updatedAt
 ) {
 	public static ProductSellResponse from(Product product, List<ProductPhoto> photos) {

--- a/src/main/java/com/napzak/domain/product/api/exception/ProductSuccessCode.java
+++ b/src/main/java/com/napzak/domain/product/api/exception/ProductSuccessCode.java
@@ -22,6 +22,7 @@ public enum ProductSuccessCode implements BaseSuccessCode {
 	PRODUCT_DETAIL_SUCCESS(HttpStatus.OK, "상품 상세 정보가 조회되었습니다."),
 	PRODUCT_UPDATE_SUCCESS(HttpStatus.OK, "상품 상태 변경이 성공하였습니다."),
 	PRODUCT_DELETE_SUCCESS(HttpStatus.OK, "상품 삭제가 성공하였습니다."),
+	PRODUCT_MODIFY_SUCCESS(HttpStatus.OK, "상품 수정이 성공하였습니다"),
 
 	/*
 	201 Created

--- a/src/main/java/com/napzak/domain/product/api/exception/ProductSuccessCode.java
+++ b/src/main/java/com/napzak/domain/product/api/exception/ProductSuccessCode.java
@@ -21,6 +21,7 @@ public enum ProductSuccessCode implements BaseSuccessCode {
 	TOP_BUY_PRODUCT_GET_SUCCESS(HttpStatus.OK, "구해요 인기 상품 목록이 조회되었습니다."),
 	PRODUCT_DETAIL_SUCCESS(HttpStatus.OK, "상품 상세 정보가 조회되었습니다."),
 	PRODUCT_UPDATE_SUCCESS(HttpStatus.OK, "상품 상태 변경이 성공하였습니다."),
+	PRODUCT_DELETE_SUCCESS(HttpStatus.OK, "상품 삭제가 성공하였습니다."),
 
 	/*
 	201 Created

--- a/src/main/java/com/napzak/domain/product/api/service/ProductService.java
+++ b/src/main/java/com/napzak/domain/product/api/service/ProductService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.napzak.domain.product.api.service.enums.SortOption;
+import com.napzak.domain.product.core.ProductPhotoRemover;
 import com.napzak.domain.product.core.ProductPhotoRetriever;
 import com.napzak.domain.product.core.ProductPhotoSaver;
 import com.napzak.domain.product.core.ProductRemover;
@@ -30,6 +31,7 @@ public class ProductService {
 	private final ProductPhotoRetriever productPhotoRetriever;
 	private final ProductSaver productSaver;
 	private final ProductPhotoSaver productPhotoSaver;
+	private final ProductPhotoRemover productPhotoRemover;
 	private final ProductUpdater productUpdater;
 	private final ProductRemover productRemover;
 
@@ -127,6 +129,19 @@ public class ProductService {
 	}
 
 	@Transactional
+	public Product updateSellProduct(
+		Long productId, String title, String description,
+		int price, Boolean isDeliveryIncluded, int standardDeliveryFee, int halfDeliveryFee,
+		ProductCondition productCondition, Long genreId
+	) {
+
+		return productUpdater.updateProduct(
+			productId, title, description, price, false, isDeliveryIncluded,
+			standardDeliveryFee, halfDeliveryFee, productCondition, genreId
+		);
+	}
+
+	@Transactional
 	public Product createBuyProduct(
 		String title, Long storeId, String description,
 		int price, Boolean isPriceNegotiable, Long genreId
@@ -141,7 +156,27 @@ public class ProductService {
 	}
 
 	@Transactional
+	public Product updateBuyProduct(
+		Long productId, String title, String description,
+		int price, Boolean isPriceNegotiable, Long genreId
+	) {
+
+		return productUpdater.updateProduct(
+			productId, title, description, price, isPriceNegotiable, false,
+			0, 0, null, genreId
+		);
+	}
+
+	@Transactional
 	public List<ProductPhoto> createProductPhotos(Long productId, Map<Integer, String> photoData) {
+
+		return productPhotoSaver.saveAll(productId, photoData);
+	}
+
+	@Transactional
+	public List<ProductPhoto> updateProductPhotos(Long productId, Map<Integer, String> photoData) {
+
+		productPhotoRemover.deleteAllByProductId(productId);
 
 		return productPhotoSaver.saveAll(productId, photoData);
 	}

--- a/src/main/java/com/napzak/domain/product/api/service/ProductService.java
+++ b/src/main/java/com/napzak/domain/product/api/service/ProductService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.napzak.domain.product.api.service.enums.SortOption;
 import com.napzak.domain.product.core.ProductPhotoRetriever;
 import com.napzak.domain.product.core.ProductPhotoSaver;
+import com.napzak.domain.product.core.ProductRemover;
 import com.napzak.domain.product.core.ProductRetriever;
 import com.napzak.domain.product.core.ProductSaver;
 import com.napzak.domain.product.core.ProductUpdater;
@@ -30,6 +31,7 @@ public class ProductService {
 	private final ProductSaver productSaver;
 	private final ProductPhotoSaver productPhotoSaver;
 	private final ProductUpdater productUpdater;
+	private final ProductRemover productRemover;
 
 	public ProductPagination getSellProducts(
 		SortOption sortOption, Long cursorProductId, Integer cursorOptionalValue, int size,
@@ -147,6 +149,11 @@ public class ProductService {
 	public Product getProduct(Long productId) {
 
 		return productRetriever.findById(productId);
+	}
+
+	public void deleteProduct(Long productId) {
+
+		productRemover.deleteById(productId);
 	}
 
 	public void updateTradeStatus(Long productId, TradeStatus tradeStatus) {

--- a/src/main/java/com/napzak/domain/product/core/ProductPhotoRemover.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductPhotoRemover.java
@@ -1,5 +1,7 @@
 package com.napzak.domain.product.core;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
 import jakarta.transaction.Transactional;
@@ -12,7 +14,9 @@ public class ProductPhotoRemover {
 	private final ProductPhotoRepository productPhotoRepository;
 
 	@Transactional
-	public void deleteAllByProductId(Long productId){
-		productPhotoRepository.deleteByProductId(productId);
+	public void deleteAllByProductPhotoIds(List<Long> ids) {
+		if (ids != null && !ids.isEmpty()) {
+			productPhotoRepository.deleteAllByProductPhotoIds(ids);
+		}
 	}
 }

--- a/src/main/java/com/napzak/domain/product/core/ProductPhotoRemover.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductPhotoRemover.java
@@ -1,0 +1,18 @@
+package com.napzak.domain.product.core;
+
+import org.springframework.stereotype.Component;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ProductPhotoRemover {
+
+	private final ProductPhotoRepository productPhotoRepository;
+
+	@Transactional
+	public void deleteAllByProductId(Long productId){
+		productPhotoRepository.deleteByProductId(productId);
+	}
+}

--- a/src/main/java/com/napzak/domain/product/core/ProductPhotoRepository.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductPhotoRepository.java
@@ -3,6 +3,7 @@ package com.napzak.domain.product.core;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -26,5 +27,8 @@ public interface ProductPhotoRepository extends JpaRepository<ProductPhotoEntity
 		"ORDER BY p.sequence ASC")
 	List<ProductPhotoEntity> findAllByProductEntityOrderBySequenceAsc(@Param("productId") Long productId);
 
-	void deleteByProductId(Long productId);
+	@Modifying
+	@Query("DELETE FROM ProductPhotoEntity  p WHERE p.id IN :ids")
+	void deleteAllByProductPhotoIds(@Param("ids") List<Long> ids);
+
 }

--- a/src/main/java/com/napzak/domain/product/core/ProductPhotoRepository.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductPhotoRepository.java
@@ -26,4 +26,5 @@ public interface ProductPhotoRepository extends JpaRepository<ProductPhotoEntity
 		"ORDER BY p.sequence ASC")
 	List<ProductPhotoEntity> findAllByProductEntityOrderBySequenceAsc(@Param("productId") Long productId);
 
+	void deleteByProductId(Long productId);
 }

--- a/src/main/java/com/napzak/domain/product/core/ProductPhotoUpdater.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductPhotoUpdater.java
@@ -1,0 +1,27 @@
+package com.napzak.domain.product.core;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.napzak.domain.product.api.exception.ProductErrorCode;
+import com.napzak.domain.product.core.entity.ProductPhotoEntity;
+import com.napzak.global.common.exception.NapzakException;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class ProductPhotoUpdater {
+
+	private final ProductPhotoRepository productPhotoRepository;
+
+	public void updateProductPhoto(Long photoId, String photoUrl, int sequence) {
+		ProductPhotoEntity productPhoto = productPhotoRepository.findById(photoId)
+			.orElseThrow(() -> new NapzakException(ProductErrorCode.PRODUCT_PHOTO_NOT_FOUND));
+
+		productPhoto.update(photoUrl, sequence);
+		productPhotoRepository.save(productPhoto);
+	}
+
+}

--- a/src/main/java/com/napzak/domain/product/core/ProductRemover.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductRemover.java
@@ -1,0 +1,18 @@
+package com.napzak.domain.product.core;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ProductRemover {
+
+	private final ProductRepository productRepository;
+
+	public void deleteById(Long productId) {
+
+		productRepository.deleteById(productId);
+
+	}
+}

--- a/src/main/java/com/napzak/domain/product/core/ProductUpdater.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductUpdater.java
@@ -5,7 +5,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.napzak.domain.product.api.exception.ProductErrorCode;
 import com.napzak.domain.product.core.entity.ProductEntity;
+import com.napzak.domain.product.core.entity.enums.ProductCondition;
 import com.napzak.domain.product.core.entity.enums.TradeStatus;
+import com.napzak.domain.product.core.vo.Product;
 import com.napzak.global.common.exception.NapzakException;
 
 import lombok.RequiredArgsConstructor;
@@ -36,5 +38,17 @@ public class ProductUpdater {
 			.orElseThrow(() -> new NapzakException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
 		productRepository.updateTradeStatus(productId, tradeStatus);
+	}
+
+	@Transactional
+	public Product updateProduct(Long productId, String title, String description, int price, Boolean isPriceNegotiable,
+		Boolean isDeliveryIncluded, int standardDeliveryFee, int halfDeliveryFee, ProductCondition productCondition, Long genreId) {
+		ProductEntity productEntity = productRepository.findById(productId)
+			.orElseThrow(() -> new NapzakException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+		productEntity.update(title, description, price, isPriceNegotiable, isDeliveryIncluded, standardDeliveryFee,
+			halfDeliveryFee, productCondition, genreId);
+
+		return Product.fromEntity(productEntity);
 	}
 }

--- a/src/main/java/com/napzak/domain/product/core/entity/ProductEntity.java
+++ b/src/main/java/com/napzak/domain/product/core/entity/ProductEntity.java
@@ -144,4 +144,27 @@ public class ProductEntity {
 			.genreId(genreId)
 			.build();
 	}
+
+	public void update(
+		final String title,
+		final String description,
+		final int price,
+		final Boolean isPriceNegotiable,
+		final Boolean isDeliveryIncluded,
+		final int standardDeliveryFee,
+		final int halfDeliveryFee,
+		final ProductCondition productCondition,
+		final Long genreId
+	) {
+		this.title = title;
+		this.description = description;
+		this.price = price;
+		this.isPriceNegotiable = isPriceNegotiable;
+		this.isDeliveryIncluded = isDeliveryIncluded;
+		this.standardDeliveryFee = standardDeliveryFee;
+		this.halfDeliveryFee = halfDeliveryFee;
+		this.productCondition = productCondition;
+		this.genreId = genreId;
+		this.updatedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/napzak/domain/product/core/entity/ProductPhotoEntity.java
+++ b/src/main/java/com/napzak/domain/product/core/entity/ProductPhotoEntity.java
@@ -46,4 +46,9 @@ public class ProductPhotoEntity {
 			.sequence(sequence)
 			.build();
 	}
+
+	public void update(String photoUrl, int sequence) {
+		this.photoUrl = photoUrl;
+		this.sequence = sequence;
+	}
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #18

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
구해요, 팔아요 상품 수정을 위한 데이터 조회 api를 구현하였습니다. 
구해요, 팔아요 상품 수정 api를 구현하였습니다.
상품 삭제 api를 구현하였습니다. 

상품 사진 수정에 대해서는 기존 사진들을 다 삭제하고 다시 save하는 게 깔끔할 것 같아 이런 방식으로 구현하였습니다. 
상품 등록과 유사한 플로우입니다. 

상품 등록 성공 때 나가는 response에 updatedAt 필드 추가하여 상품 수정 api에서도 해당 dto 사용하였습니다.  

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
### 상품 삭제

￼<img width="845" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/6f22595f-1b5e-48c7-84b8-d04d7e837478" />

### 수정을 위한 팔아요 상품 조회 
￼
<img width="872" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/71731f96-aee8-4bbf-8564-d1e96924ff7e" />

### 수정을 위한 구해요 상품 조회 
￼
<img width="833" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/24af8dc4-e334-43d5-89e9-1ca1baca2a74" />

### 팔아요 상품 수정
￼
<img width="1089" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/9f3802a4-993a-42e1-a926-375bcbbff799" />

### 구해요 상품 수정
￼
<img width="1072" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/d08320bb-4652-4c81-875c-7bf8c7dd4f4c" />



---
코드리뷰 반영 

### buy 수정 api 요청 전 
<img width="571" alt="image" src="https://github.com/user-attachments/assets/75783256-d034-4a01-ab8e-1f3df310f67b" />

### buy 수정 api 요청

#### request
<img width="560" alt="image" src="https://github.com/user-attachments/assets/1df8e3f1-1269-43e0-8d07-a38b4ca4b32e" />

#### response
<img width="546" alt="image" src="https://github.com/user-attachments/assets/8b010f4d-d3f7-4837-8748-e30734fc4f1f" />

의도한 것 
- 첫번째 사진은 그대로 유지
- 두번째 사진은 url 및 순서 변경
- 세번째 사진은 순서만 변경 
- 네번째 사진은 새롭게 추가
- db에는 존재하나 요청에 존재하지 않는 사진은 db에서 삭제

구해요 상품 수정 api도 정상 작동합니다. 


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
