### PR TITLE
[feat] #29 - 장르 페이지 정보 조회 api 구현

### DIFF
--- a/src/main/java/com/napzak/domain/genre/api/controller/GenreController.java
+++ b/src/main/java/com/napzak/domain/genre/api/controller/GenreController.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,15 +13,18 @@ import com.napzak.domain.external.core.entity.enums.LinkType;
 import com.napzak.domain.genre.api.GenreLinkFacade;
 import com.napzak.domain.genre.api.dto.response.GenreListResponse;
 import com.napzak.domain.genre.api.dto.response.GenreNameListResponse;
+import com.napzak.domain.genre.api.dto.response.GenrePageResponse;
 import com.napzak.domain.genre.api.exception.GenreSuccessCode;
 import com.napzak.domain.genre.api.service.GenrePagination;
 import com.napzak.domain.genre.api.service.GenreService;
 import com.napzak.domain.genre.api.service.enums.SortOption;
+import com.napzak.domain.genre.core.vo.Genre;
 import com.napzak.global.auth.annotation.CurrentMember;
 import com.napzak.global.common.exception.NapzakException;
 import com.napzak.global.common.exception.code.ErrorCode;
 import com.napzak.global.common.exception.dto.SuccessResponse;
 import com.napzak.domain.genre.api.dto.request.cursor.OldestCursor;
+import com.sun.net.httpserver.Authenticator;
 
 import lombok.RequiredArgsConstructor;
 
@@ -125,6 +129,18 @@ public class GenreController implements GenreApi {
 		return ResponseEntity.ok(
 			SuccessResponse.of(successCode, response, genreLink)
 		);
+	}
+
+	@GetMapping("genres/detail/{genreId}")
+	public ResponseEntity<SuccessResponse<GenrePageResponse>> getGenrePage(
+		@CurrentMember Long storeId,
+		@PathVariable Long genreId
+	) {
+		Genre genre = genreService.searchGenre(genreId);
+		GenrePageResponse genrePageResponse = GenrePageResponse.from(genre.getId(), genre.getName(), genre.getTag(), genre.getCover());
+
+		return ResponseEntity.ok()
+			.body(SuccessResponse.of(GenreSuccessCode.GENRE_PAGE_GET_SUCCESS, genrePageResponse));
 	}
 
 	private Long parseCursorValues(String cursor, SortOption sortOption) {

--- a/src/main/java/com/napzak/domain/genre/api/dto/response/GenrePageResponse.java
+++ b/src/main/java/com/napzak/domain/genre/api/dto/response/GenrePageResponse.java
@@ -1,0 +1,17 @@
+package com.napzak.domain.genre.api.dto.response;
+
+public record GenrePageResponse(
+	long genreId,
+	String genreName,
+	String tag,
+	String cover
+) {
+	public static GenrePageResponse from(
+		long genreId,
+		String genreName,
+		String tag,
+		String cover
+	) {
+		return new GenrePageResponse(genreId, genreName, tag, cover);
+	}
+}

--- a/src/main/java/com/napzak/domain/genre/api/exception/GenreSuccessCode.java
+++ b/src/main/java/com/napzak/domain/genre/api/exception/GenreSuccessCode.java
@@ -16,6 +16,7 @@ public enum GenreSuccessCode implements BaseSuccessCode {
 	GENRE_LIST_RETRIEVE_SUCCESS(HttpStatus.OK, "장르 목록이 조회되었습니다."),
 	GENRE_LIST_SEARCH_SUCCESS(HttpStatus.OK, "검색된 장르 목록이 조회되었습니다."),
 	GENRE_SEARCH_NO_RESULT(HttpStatus.OK, "검색 결과가 없습니다."),
+	GENRE_PAGE_GET_SUCCESS(HttpStatus.OK, "장르 페이지 데이터가 조회되었습니다."),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/napzak/domain/genre/api/service/GenreService.java
+++ b/src/main/java/com/napzak/domain/genre/api/service/GenreService.java
@@ -27,4 +27,8 @@ public class GenreService {
 
 		return new GenrePagination(size, new GenreList(genres));
 	}
+
+	public Genre searchGenre(long genreId) {
+		return genreRetriever.findByGenreId(genreId);
+	}
 }

--- a/src/main/java/com/napzak/domain/genre/core/GenreRetriever.java
+++ b/src/main/java/com/napzak/domain/genre/core/GenreRetriever.java
@@ -7,8 +7,11 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.napzak.domain.genre.api.exception.GenreErrorCode;
 import com.napzak.domain.genre.api.service.enums.SortOption;
+import com.napzak.domain.genre.core.entity.GenreEntity;
 import com.napzak.domain.genre.core.vo.Genre;
+import com.napzak.global.common.exception.NapzakException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -56,5 +59,12 @@ public class GenreRetriever {
 		return genreRepository.findExistingGenreEntityList(genreIds).stream()
 			.map(Genre::fromEntity)
 			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public Genre findByGenreId(Long genreId) {
+		GenreEntity genreEntity = genreRepository.findById(genreId)
+			.orElseThrow(()-> new NapzakException(GenreErrorCode.GENRE_NOT_FOUND));
+		return Genre.fromEntity(genreEntity);
 	}
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #29

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
장르 페이지 정보 조회 api를 구현하였습니다. 
태그 지정되어 있지 않은 경우 태그 필드 null로 반환됩니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="672" alt="image" src="https://github.com/user-attachments/assets/6c7b6344-f95e-4cf0-84f3-b992a0211d65" />


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->