### PR TITLE
[feat] #33 - 닉네임 검증 api 구현

### DIFF
--- a/src/main/java/com/napzak/domain/store/api/controller/StoreApi.java
+++ b/src/main/java/com/napzak/domain/store/api/controller/StoreApi.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import com.napzak.domain.genre.api.dto.response.GenreNameListResponse;
 import com.napzak.domain.store.api.dto.request.GenrePreferenceRequest;
+import com.napzak.domain.store.api.dto.request.NicknameRequest;
 import com.napzak.domain.store.api.dto.response.AccessTokenGenerateResponse;
 import com.napzak.domain.store.api.dto.response.MyPageResponse;
 import com.napzak.domain.store.api.dto.response.StoreInfoResponse;
@@ -72,6 +73,21 @@ public interface StoreApi {
 		@CookieValue("refreshToken") String refreshToken
 	);
 
+	@Operation(summary = "닉네임 중복 및 비속어 검증", description = "닉네임의 중복 여부와 비속어 포함 여부를 검증합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "유효한 닉네임"),
+		@ApiResponse(responseCode = "400", description = "닉네임에 비속어 포함"),
+		@ApiResponse(responseCode = "409", description = "중복된 닉네임")
+	})
+	@PostMapping("/nickname/check")
+	ResponseEntity<SuccessResponse<Void>> checkNickname(
+		@io.swagger.v3.oas.annotations.parameters.RequestBody(
+			description = "닉네임 검증 요청", required = true,
+			content = @Content(schema = @Schema(implementation = NicknameRequest.class))
+		)
+		@RequestBody NicknameRequest request
+	);
+
 	@Operation(summary = "마이페이지 조회", description = "마이페이지 정보 조회 API")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "마이페이지 조회 성공",
@@ -107,4 +123,12 @@ public interface StoreApi {
 
 		@Valid @RequestBody GenrePreferenceRequest genrePreferenceList
 	);
+
+	@Operation(summary = "비속어 Redis 동기화", description = "DB의 비속어 목록을 Redis로 동기화합니다. (관리자 전용)")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "Redis 비속어 목록 동기화 성공")
+	})
+	@PostMapping("/admin/sync-redis/slangs")
+	ResponseEntity<SuccessResponse<Void>> syncSlangToRedis(@CurrentMember Long currentStoreId);
+
 }

--- a/src/main/java/com/napzak/domain/store/api/controller/StoreController.java
+++ b/src/main/java/com/napzak/domain/store/api/controller/StoreController.java
@@ -28,6 +28,7 @@ import com.napzak.domain.store.api.StoreGenreFacade;
 import com.napzak.domain.store.api.StoreLinkFacade;
 import com.napzak.domain.store.api.StoreProductFacade;
 import com.napzak.domain.store.api.dto.request.GenrePreferenceRequest;
+import com.napzak.domain.store.api.dto.request.NicknameRequest;
 import com.napzak.domain.store.api.dto.response.AccessTokenGenerateResponse;
 import com.napzak.domain.store.api.dto.response.LoginSuccessResponse;
 import com.napzak.domain.store.api.dto.response.MyPageResponse;
@@ -110,6 +111,14 @@ public class StoreController implements StoreApi {
 		return ResponseEntity.ok(SuccessResponse.of(StoreSuccessCode.ACCESS_TOKEN_REISSUE_SUCCESS, accessTokenGenerateResponse));
 	}
 
+	@PostMapping("/nickname/check")
+	public ResponseEntity<SuccessResponse<Void>> checkNickname(
+		@RequestBody NicknameRequest request
+	) {
+		storeService.validateNickname(request.nickname());
+		return ResponseEntity.ok(SuccessResponse.of(StoreSuccessCode.VALID_NICKNAME_SUCCESS));
+	}
+
 	@GetMapping("/mypage")
 	public ResponseEntity<SuccessResponse<MyPageResponse>> getMyPageInfo(
 		@CurrentMember final Long currentStoreId
@@ -175,7 +184,7 @@ public class StoreController implements StoreApi {
 
 	@PostMapping("genres/register")
 	public ResponseEntity<SuccessResponse<GenreNameListResponse>> register(
-		@CurrentMember final Long currentMemberId,
+		@CurrentMember final Long currentStoreId,
 		@Valid @RequestBody final GenrePreferenceRequest genrePreferenceList
 	) {
 
@@ -201,7 +210,7 @@ public class StoreController implements StoreApi {
 				throw new NapzakException(GenreErrorCode.GENRE_NOT_FOUND);
 			}
 		}
-		storeRegistrationService.registerGenrePreference(currentMemberId, genreIds);
+		storeRegistrationService.registerGenrePreference(currentStoreId, genreIds);
 
 		List<GenreNameDto> genrePreferenceDto = genreList.stream()
 			.map(genre -> GenreNameDto.from(genre.getId(), genre.getName()))
@@ -210,6 +219,14 @@ public class StoreController implements StoreApi {
 		GenreNameListResponse response = GenreNameListResponse.fromWithoutCursor(genrePreferenceDto);
 		return ResponseEntity.ok()
 			.body(SuccessResponse.of(StoreSuccessCode.GENRE_PREPERENCE_REGISTER_SUCCESS, response));
+	}
+
+	@PostMapping("/admin/sync-redis/slangs")
+	public ResponseEntity<SuccessResponse<Void>> syncSlangToRedis(
+		@CurrentMember final Long currentStoreId
+	) {
+		storeService.syncSlangToRedis();
+		return ResponseEntity.ok(SuccessResponse.of(StoreSuccessCode.SLANG_REDIS_UPDATE_SUCCESS));
 	}
 
 	private List<GenreNameDto> genrePreferenceResponseGenerator(List<GenrePreference> genreList) {

--- a/src/main/java/com/napzak/domain/store/api/dto/request/NicknameRequest.java
+++ b/src/main/java/com/napzak/domain/store/api/dto/request/NicknameRequest.java
@@ -1,0 +1,6 @@
+package com.napzak.domain.store.api.dto.request;
+
+public record NicknameRequest(
+	String nickname
+) {
+}

--- a/src/main/java/com/napzak/domain/store/api/exception/StoreErrorCode.java
+++ b/src/main/java/com/napzak/domain/store/api/exception/StoreErrorCode.java
@@ -15,11 +15,17 @@ public enum StoreErrorCode implements BaseErrorCode {
  	*/
 	INVALID_GENRE_PREFERENCE_COUNT(HttpStatus.BAD_REQUEST, "선호 장르 리스트는 최대 4개까지 입력할 수 있습니다."),
 	DUPLICATE_GENRE_PREFERENCES(HttpStatus.BAD_REQUEST, "선호 장르 리스트에 중복된 값이 있습니다."),
+	NICKNAME_CONTAINS_SLANG(HttpStatus.BAD_REQUEST, "욕설이나 비속어를 사용할 수 없어요."),
 
 	/*
 	404 Not Found
 	 */
 	STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 사용자가 없습니다."),
+
+	/*
+	409 Conflict
+	 */
+	DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용중인 이름이에요."),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/napzak/domain/store/api/exception/StoreSuccessCode.java
+++ b/src/main/java/com/napzak/domain/store/api/exception/StoreSuccessCode.java
@@ -20,6 +20,9 @@ public enum StoreSuccessCode implements BaseSuccessCode {
 	GET_SETTING_LINK_SUCCESS(HttpStatus.OK, "설정 링크 조회 성공"),
 	ACCESS_TOKEN_REISSUE_SUCCESS(HttpStatus.OK, "액세스 토큰 재발급 성공"),
 	GET_ONBOARDING_TERMS_SUCCESS(HttpStatus.OK, "온보딩 약관 정보 조회 성공"),
+	VALID_NICKNAME_SUCCESS(HttpStatus.OK, "사용할 수 있는 닉네임이에요!"),
+	NICKNAME_REGISTER_SUCCESS(HttpStatus.OK, "닉네임이 등록되었습니다."),
+	SLANG_REDIS_UPDATE_SUCCESS(HttpStatus.OK, "redis 비속어 업데이트 성공"),
 
 	/*
 	201 Created

--- a/src/main/java/com/napzak/domain/store/api/service/StoreService.java
+++ b/src/main/java/com/napzak/domain/store/api/service/StoreService.java
@@ -8,10 +8,12 @@ import org.springframework.transaction.annotation.Transactional;
 import com.napzak.domain.store.api.exception.StoreErrorCode;
 import com.napzak.domain.store.core.GenrePreferenceRetriever;
 import com.napzak.domain.store.core.StoreRetriever;
+import com.napzak.domain.store.core.entity.SlangRetriever;
 import com.napzak.domain.store.core.entity.enums.SocialType;
 import com.napzak.domain.store.core.vo.GenrePreference;
 import com.napzak.domain.store.core.vo.Store;
 import com.napzak.global.common.exception.NapzakException;
+import com.napzak.global.common.slang.SlangFilter;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +25,8 @@ import lombok.extern.slf4j.Slf4j;
 public class StoreService {
 	private final StoreRetriever storeRetriever;
 	private final GenrePreferenceRetriever genrePreferenceRetriever;
+	private final SlangRetriever slangRetriever;
+	private final SlangFilter slangFilter;
 
 	@Transactional(readOnly = true)
 	public Store findStoreByStoreId(Long StoreId) {
@@ -55,4 +59,18 @@ public class StoreService {
 		return genrePreferenceRetriever.getGenrePreferences(storeId);
 	}
 
+	@Transactional(readOnly = true)
+	public void validateNickname(String nickname) {
+		if (storeRetriever.existsByNickname(nickname)) {
+			throw new NapzakException(StoreErrorCode.DUPLICATE_NICKNAME);
+		}
+
+		if (slangFilter.containsSlang(nickname)) {
+			throw new NapzakException(StoreErrorCode.NICKNAME_CONTAINS_SLANG);
+		}
+	}
+
+	public void syncSlangToRedis() {
+		slangRetriever.updateSlangToRedis();
+	}
 }

--- a/src/main/java/com/napzak/domain/store/core/SlangRepository.java
+++ b/src/main/java/com/napzak/domain/store/core/SlangRepository.java
@@ -1,0 +1,8 @@
+package com.napzak.domain.store.core;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.napzak.domain.store.core.entity.SlangEntity;
+
+public interface SlangRepository extends JpaRepository<SlangEntity, Long> {
+}

--- a/src/main/java/com/napzak/domain/store/core/StoreRepository.java
+++ b/src/main/java/com/napzak/domain/store/core/StoreRepository.java
@@ -35,4 +35,6 @@ public interface StoreRepository extends JpaRepository<StoreEntity, Long> {
 	@Query("SELECT u.nickname FROM StoreEntity u WHERE u.id = :storeId")
 	String findNicknameById(@Param("storeId") Long storeId);
 
+	boolean existsByNickname(String nickname);
+
 }

--- a/src/main/java/com/napzak/domain/store/core/StoreRetriever.java
+++ b/src/main/java/com/napzak/domain/store/core/StoreRetriever.java
@@ -66,4 +66,9 @@ public class StoreRetriever {
 	public String findNicknameByStoreId(Long storeId) {
 		return storeRepository.findNicknameById(storeId);
 	}
+
+	@Transactional(readOnly = true)
+	public boolean existsByNickname(String nickname) {
+		return storeRepository.existsByNickname(nickname);
+	}
 }

--- a/src/main/java/com/napzak/domain/store/core/entity/SlangRetriever.java
+++ b/src/main/java/com/napzak/domain/store/core/entity/SlangRetriever.java
@@ -1,0 +1,61 @@
+package com.napzak.domain.store.core.entity;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.napzak.domain.store.core.SlangRepository;
+import com.napzak.global.common.slang.KoreanUtils;
+import com.napzak.global.common.slang.SlangFilter;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SlangRetriever {
+
+	private final SlangRepository slangRepository;
+	private final RedisTemplate<String, String> redisTemplate;
+
+	private static final String RAW_SET = "slang:raw";
+	private static final String JAMO_SET = "slang:jamo";
+	private static final String MIXED_SET = "slang:mixed";
+
+	@EventListener(ApplicationReadyEvent.class)
+	public void preloadSlang() {
+		updateSlangToRedis();
+	}
+
+	public void updateSlangToRedis() {
+		List<SlangEntity> slangs = slangRepository.findAll();
+
+		Set<String> rawWords = slangs.stream()
+			.map(SlangEntity::getWord)
+			.filter(w -> w.matches("[a-zA-Z]+"))
+			.collect(Collectors.toSet());
+
+		Set<String> jamoWords = slangs.stream()
+			.map(SlangEntity::getWord)
+			.map(KoreanUtils::extractJamo)
+			.collect(Collectors.toSet());
+
+		Set<String> mixedWords = slangs.stream()
+			.map(SlangEntity::getWord)
+			.map(KoreanUtils::extractJamo)
+			.map(SlangFilter::normalizeMixed)
+			.collect(Collectors.toSet());
+
+		redisTemplate.delete(RAW_SET);
+		redisTemplate.delete(JAMO_SET);
+		redisTemplate.delete(MIXED_SET);
+
+		redisTemplate.opsForSet().add(RAW_SET, rawWords.toArray(new String[0]));
+		redisTemplate.opsForSet().add(JAMO_SET, jamoWords.toArray(new String[0]));
+		redisTemplate.opsForSet().add(MIXED_SET, mixedWords.toArray(new String[0]));
+	}
+}

--- a/src/main/java/com/napzak/global/auth/redis/LettuceLockRepository.java
+++ b/src/main/java/com/napzak/global/auth/redis/LettuceLockRepository.java
@@ -11,14 +11,15 @@ import lombok.RequiredArgsConstructor;
 @Repository
 public class LettuceLockRepository {
 	private final RedisTemplate<String, String> redisTemplate;
+	private static final String LOCK_PREFIX = "lock:";
 
 	public Boolean lock(String token, String lockType) {
 		return redisTemplate
 			.opsForValue()
-			.setIfAbsent(token, lockType, Duration.ofSeconds(3L));
+			.setIfAbsent(LOCK_PREFIX + token, lockType, Duration.ofSeconds(3L));
 	}
 
 	public void unlock(String token) {
-		redisTemplate.delete(token);
+		redisTemplate.delete(LOCK_PREFIX + token);
 	}
 }

--- a/src/main/java/com/napzak/global/common/slang/KoreanUtils.java
+++ b/src/main/java/com/napzak/global/common/slang/KoreanUtils.java
@@ -1,0 +1,37 @@
+package com.napzak.global.common.slang;
+
+public class KoreanUtils {
+
+	private static final char[] INITIAL_JAMOS = {
+		'ㄱ','ㄲ','ㄴ','ㄷ','ㄸ','ㄹ','ㅁ','ㅂ','ㅃ','ㅅ','ㅆ','ㅇ','ㅈ','ㅉ','ㅊ','ㅋ','ㅌ','ㅍ','ㅎ'
+	};
+
+	private static final char[] MEDIAL_JAMOS = {
+		'ㅏ','ㅐ','ㅑ','ㅒ','ㅓ','ㅔ','ㅕ','ㅖ','ㅗ','ㅘ','ㅙ','ㅚ',
+		'ㅛ','ㅜ','ㅝ','ㅞ','ㅟ','ㅠ','ㅡ','ㅢ','ㅣ'
+	};
+
+	private static final char[] FINAL_JAMOS = {
+		'\0','ㄱ','ㄲ','ㄳ','ㄴ','ㄵ','ㄶ','ㄷ','ㄹ','ㄺ','ㄻ','ㄼ','ㄽ','ㄾ','ㄿ','ㅀ','ㅁ','ㅂ',
+		'ㅄ','ㅅ','ㅆ','ㅇ','ㅈ','ㅊ','ㅋ','ㅌ','ㅍ','ㅎ'
+	};
+
+	public static String extractJamo(String input) {
+		StringBuilder sb = new StringBuilder();
+		for (char ch : input.toCharArray()) {
+			if (ch >= 0xAC00 && ch <= 0xD7A3) {
+				int base = ch - 0xAC00;
+				int initialIndex = base / (21 * 28);
+				int medialIndex = (base % (21 * 28)) / 28;
+				int finalIndex = base % 28;
+
+				sb.append(INITIAL_JAMOS[initialIndex]);
+				sb.append(MEDIAL_JAMOS[medialIndex]);
+				if (finalIndex != 0) sb.append(FINAL_JAMOS[finalIndex]);
+			} else if ((ch >= 0x3131 && ch <= 0x318E)) {
+				sb.append(ch);
+			}
+		}
+		return sb.toString();
+	}
+}

--- a/src/main/java/com/napzak/global/common/slang/MixedNormalizeMap.java
+++ b/src/main/java/com/napzak/global/common/slang/MixedNormalizeMap.java
@@ -1,0 +1,16 @@
+package com.napzak.global.common.slang;
+
+import java.util.Map;
+
+public class MixedNormalizeMap {
+	private static final Map<Character, Character> map = Map.ofEntries(
+		Map.entry('1', 'ㅣ'), Map.entry('i', 'ㅣ'), Map.entry('l', 'ㅣ'), Map.entry('|', 'ㅣ'),
+		Map.entry('s', 'ㅅ'), Map.entry('$', 'ㅅ'),
+		Map.entry('b', 'ㅂ'), Map.entry('a', 'ㅏ'), Map.entry('o', 'ㅗ'),
+		Map.entry('0', 'ㅇ'), Map.entry('c', 'ㅋ'), Map.entry('k', 'ㅋ')
+	);
+
+	public static char getOrDefault(char key, char defaultValue) {
+		return map.getOrDefault(key, defaultValue);
+	}
+}

--- a/src/main/java/com/napzak/global/common/slang/SlangFilter.java
+++ b/src/main/java/com/napzak/global/common/slang/SlangFilter.java
@@ -1,0 +1,84 @@
+package com.napzak.global.common.slang;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SlangFilter {
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	private static final String RAW_SET = "slang:raw";
+	private static final String JAMO_SET = "slang:jamo";
+	private static final String MIXED_SET = "slang:mixed";
+	private static final int MIN_SLANG_LENGTH = 2;
+
+	public boolean containsSlang(String input) {
+		String onlyEng = input.replaceAll("[^a-zA-Z]", "").toLowerCase();
+		boolean hasEng = !onlyEng.isEmpty();
+		boolean hasKor = input.matches(".*[가-힣ㄱ-ㅎㅏ-ㅣ].*");
+
+		if (hasEng && containsOrdered(onlyEng, redisTemplate.opsForSet().members(RAW_SET))) return true;
+
+		String rawJamo = KoreanUtils.extractJamo(input);
+		if (containsStrictSubstring(rawJamo, redisTemplate.opsForSet().members(JAMO_SET))) return true;
+
+		if (hasKor || (hasEng && input.length() <= 10)) {
+			String normalized = normalizeMixed(input);
+			String jamo = KoreanUtils.extractJamo(normalized);
+
+			if (containsStrictSubstring(jamo, redisTemplate.opsForSet().members(JAMO_SET))) return true;
+			if (containsOrdered(normalized, redisTemplate.opsForSet().members(MIXED_SET))) return true;
+		}
+
+		return false;
+	}
+
+	private boolean containsOrdered(String input, Set<String> slangSet) {
+		if (slangSet == null || slangSet.isEmpty()) return false;
+		for (String slang : slangSet) {
+			if (slang == null || slang.length() < MIN_SLANG_LENGTH) continue;
+			if (isOrderedSubstring(input, slang)) return true;
+		}
+		return false;
+	}
+
+	private boolean containsStrictSubstring(String input, Set<String> slangSet) {
+		if (slangSet == null || slangSet.isEmpty()) return false;
+		for (String slang : slangSet) {
+			if (slang == null || slang.length() < MIN_SLANG_LENGTH) continue;
+			if (input.contains(slang)) return true;
+		}
+		return false;
+	}
+
+	private boolean isOrderedSubstring(String text, String pattern) {
+		if (pattern == null || pattern.isEmpty()) return false;
+		int idx = 0;
+		for (char ch : text.toCharArray()) {
+			if (ch == pattern.charAt(idx)) {
+				idx++;
+				if (idx == pattern.length()) return true;
+			}
+		}
+		return false;
+	}
+
+	public static String normalizeMixed(String input) {
+		StringBuilder sb = new StringBuilder();
+		for (char ch : input.toLowerCase().toCharArray()) {
+			if (Character.isAlphabetic(ch) || Character.isDigit(ch)) {
+				sb.append(MixedNormalizeMap.getOrDefault(ch, ch));
+			} else {
+				sb.append(ch);
+			}
+		}
+		return sb.toString();
+	}
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #33 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

### ✅ 닉네임 중복 및 비속어 검증 API (POST /api/v1/stores/nickname/check)
- 닉네임 중복 여부 확인 (409 Conflict)
- Redis 기반 비속어 필터링 로직 적용 (400 Bad Request)
- 한글/영문/숫자 혼용 케이스 처리:
예: ㅅ1발, s1bal, 시1발, ㅅi발 모두 감지
- SlangFilter를 통해 normalize + 자모 분리 후 감지

### ✅ 슬랭 Redis 초기화 API (POST /api/v1/stores/admin/sync-redis/slangs)
- slang DB(word 기준) → 자모/혼합/영문 변환 → Redis 저장
- 저장 키:
slang:raw - 영문 기반 (예: sibal)
slang:jamo - 자모 기준 (예: ㅅㅣㅂㅏㄹ)
slang:mixed - normalize 된 혼합 문자열

### 🧠 기술적 핵심
SlangFilter:
- normalizeMixed → 한글/영문/숫자 변환 처리
- extractJamo → 조합형 한글 자모 추출
- containsOrdered / containsStrictSubstring 으로 감지 정밀도 조절

오탐 방지 처리:
- 단건 자모 무시 (length < 2)
- slang:jamo는 연속 포함(.contains()), 나머지는 순서 일치 기반

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
