### PR TITLE
[feat] #35 - 상점 프로필 수정 관련 api 구현

### DIFF
--- a/src/main/java/com/napzak/domain/store/api/controller/StoreApi.java
+++ b/src/main/java/com/napzak/domain/store/api/controller/StoreApi.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -12,10 +13,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.napzak.domain.genre.api.dto.response.GenreNameListResponse;
 import com.napzak.domain.store.api.dto.request.GenrePreferenceRequest;
 import com.napzak.domain.store.api.dto.request.NicknameRequest;
+import com.napzak.domain.store.api.dto.request.StoreProfileModifyRequest;
 import com.napzak.domain.store.api.dto.response.AccessTokenGenerateResponse;
 import com.napzak.domain.store.api.dto.response.MyPageResponse;
 import com.napzak.domain.store.api.dto.response.StoreInfoResponse;
 import com.napzak.domain.store.api.dto.response.StoreLoginResponse;
+import com.napzak.domain.store.api.dto.response.StoreProfileModifyResponse;
 import com.napzak.global.auth.annotation.CurrentMember;
 import com.napzak.global.auth.client.dto.StoreSocialLoginRequest;
 import com.napzak.global.common.exception.dto.SuccessResponse;
@@ -86,6 +89,37 @@ public interface StoreApi {
 			content = @Content(schema = @Schema(implementation = NicknameRequest.class))
 		)
 		@RequestBody NicknameRequest request
+	);
+
+	@Operation(summary = "닉네임 등록", description = "스토어의 닉네임을 등록하고, 역할을 STORE로 설정합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "닉네임 등록 성공")
+	})
+	@PostMapping("/nickname/register")
+	ResponseEntity<SuccessResponse<Void>> registerNickname(
+		@CurrentMember Long currentStoreId,
+		@RequestBody @Valid NicknameRequest request
+	);
+
+	@Operation(summary = "상점 프로필 수정용 정보 조회", description = "상점 프로필 수정을 위한 커버, 프로필, 닉네임, 설명, 장르 목록을 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "상점 프로필이 성공적으로 조회되었습니다.",
+			content = @Content(schema = @Schema(implementation = StoreProfileModifyResponse.class))),
+		@ApiResponse(responseCode = "404", description = "스토어를 찾을 수 없습니다.")
+	})
+	@GetMapping("/modify/profile")
+	ResponseEntity<SuccessResponse<StoreProfileModifyResponse>> getProfileForModify(@CurrentMember Long currentStoreId);
+
+	@Operation(summary = "상점 프로필 수정", description = "상점의 커버, 프로필 사진, 닉네임, 설명, 선호 장르를 수정합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "상점 프로필이 성공적으로 수정되었습니다.",
+			content = @Content(schema = @Schema(implementation = StoreProfileModifyResponse.class))),
+		@ApiResponse(responseCode = "400", description = "요청 필드 값이 유효하지 않습니다.")
+	})
+	@PutMapping("/modify/profile")
+	ResponseEntity<SuccessResponse<StoreProfileModifyResponse>> modifyProfile(
+		@CurrentMember Long currentStoreId,
+		@RequestBody @Valid StoreProfileModifyRequest request
 	);
 
 	@Operation(summary = "마이페이지 조회", description = "마이페이지 정보 조회 API")

--- a/src/main/java/com/napzak/domain/store/api/dto/request/NicknameRequest.java
+++ b/src/main/java/com/napzak/domain/store/api/dto/request/NicknameRequest.java
@@ -1,6 +1,9 @@
 package com.napzak.domain.store.api.dto.request;
 
+import jakarta.validation.constraints.Size;
+
 public record NicknameRequest(
+	@Size(max = 20)
 	String nickname
 ) {
 }

--- a/src/main/java/com/napzak/domain/store/api/dto/request/StoreProfileModifyRequest.java
+++ b/src/main/java/com/napzak/domain/store/api/dto/request/StoreProfileModifyRequest.java
@@ -1,0 +1,19 @@
+package com.napzak.domain.store.api.dto.request;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import jakarta.validation.constraints.Size;
+
+public record StoreProfileModifyRequest(
+	String storeCover,
+	String storePhoto,
+	@Size(max = 20)
+	String storeNickName,
+	@Nullable
+	@Size(max = 200)
+	String storeDescription,
+	List<Long> preferredGenreList
+) {
+}

--- a/src/main/java/com/napzak/domain/store/api/dto/response/StoreProfileModifyResponse.java
+++ b/src/main/java/com/napzak/domain/store/api/dto/response/StoreProfileModifyResponse.java
@@ -1,0 +1,18 @@
+package com.napzak.domain.store.api.dto.response;
+
+import java.util.List;
+
+import com.napzak.domain.genre.api.dto.response.GenreNameDto;
+
+public record StoreProfileModifyResponse(
+	String storeCover,
+	String storePhoto,
+	String storeNickName,
+	String storeDescription,
+	List<GenreNameDto> preferredGenreList
+) {
+	public static StoreProfileModifyResponse of(String storeCover, String storePhoto, String storeNickName,
+		String storeDescription, List<GenreNameDto> preferredGenreList) {
+		return new StoreProfileModifyResponse(storeCover, storePhoto, storeNickName, storeDescription, preferredGenreList);
+	}
+}

--- a/src/main/java/com/napzak/domain/store/api/exception/StoreSuccessCode.java
+++ b/src/main/java/com/napzak/domain/store/api/exception/StoreSuccessCode.java
@@ -23,6 +23,8 @@ public enum StoreSuccessCode implements BaseSuccessCode {
 	VALID_NICKNAME_SUCCESS(HttpStatus.OK, "사용할 수 있는 닉네임이에요!"),
 	NICKNAME_REGISTER_SUCCESS(HttpStatus.OK, "닉네임이 등록되었습니다."),
 	SLANG_REDIS_UPDATE_SUCCESS(HttpStatus.OK, "redis 비속어 업데이트 성공"),
+	GET_PROFILE_SUCCESS(HttpStatus.OK, "상점 프로필이 성공적으로 조회되었습니다."),
+	PROFILE_UPDATE_SUCCESS(HttpStatus.OK, "상점 프로필이 성공적으로 수정되었습니다."),
 
 	/*
 	201 Created

--- a/src/main/java/com/napzak/domain/store/api/service/StoreRegistrationService.java
+++ b/src/main/java/com/napzak/domain/store/api/service/StoreRegistrationService.java
@@ -40,6 +40,7 @@ public class StoreRegistrationService {
 		return store.getId();
 	}
 
+	@Transactional
 	public void registerGenrePreference(
 		Long currentStoreId,
 		List<Long> genrePreferenceList

--- a/src/main/java/com/napzak/domain/store/api/service/StoreService.java
+++ b/src/main/java/com/napzak/domain/store/api/service/StoreService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.napzak.domain.store.api.exception.StoreErrorCode;
 import com.napzak.domain.store.core.GenrePreferenceRetriever;
 import com.napzak.domain.store.core.StoreRetriever;
+import com.napzak.domain.store.core.StoreUpdater;
 import com.napzak.domain.store.core.entity.SlangRetriever;
 import com.napzak.domain.store.core.entity.enums.SocialType;
 import com.napzak.domain.store.core.vo.GenrePreference;
@@ -27,6 +28,7 @@ public class StoreService {
 	private final GenrePreferenceRetriever genrePreferenceRetriever;
 	private final SlangRetriever slangRetriever;
 	private final SlangFilter slangFilter;
+	private final StoreUpdater storeUpdater;
 
 	@Transactional(readOnly = true)
 	public Store findStoreByStoreId(Long StoreId) {
@@ -68,6 +70,17 @@ public class StoreService {
 		if (slangFilter.containsSlang(nickname)) {
 			throw new NapzakException(StoreErrorCode.NICKNAME_CONTAINS_SLANG);
 		}
+	}
+
+	@Transactional
+	public void registerNickname(final Long storeId, final String nickname){
+		storeUpdater.registerNicknameAndSetRole(storeId, nickname);
+	}
+
+	@Transactional
+	public void modifyProfile(final Long storeId, final String cover, final String photo,
+		final String nickname, final String description){
+		storeUpdater.updateProfile(storeId, cover, photo, nickname, description);
 	}
 
 	public void syncSlangToRedis() {

--- a/src/main/java/com/napzak/domain/store/core/StoreUpdater.java
+++ b/src/main/java/com/napzak/domain/store/core/StoreUpdater.java
@@ -1,0 +1,38 @@
+package com.napzak.domain.store.core;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.napzak.domain.store.api.exception.StoreErrorCode;
+import com.napzak.domain.store.core.entity.StoreEntity;
+import com.napzak.domain.store.core.entity.enums.Role;
+import com.napzak.global.common.exception.NapzakException;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class StoreUpdater {
+
+	private final StoreRepository storeRepository;
+
+	@Transactional
+	public void registerNicknameAndSetRole(final Long storeId, final String nickname) {
+		StoreEntity storeEntity = storeRepository.findById(storeId)
+			.orElseThrow(() -> new NapzakException(StoreErrorCode.STORE_NOT_FOUND));
+		storeEntity.setNickname(nickname);
+		storeEntity.setRole(Role.STORE);
+		storeRepository.save(storeEntity);
+	}
+
+	@Transactional
+	public void updateProfile(final Long storeId, final String cover, final String photo,
+		final String nickname, final String description) {
+		StoreEntity storeEntity = storeRepository.findById(storeId)
+			.orElseThrow(() -> new NapzakException(StoreErrorCode.STORE_NOT_FOUND));
+		storeEntity.setCover(cover);
+		storeEntity.setPhoto(photo);
+		storeEntity.setNickname(nickname);
+		storeEntity.setDescription(description);
+	}
+}

--- a/src/main/java/com/napzak/domain/store/core/entity/StoreEntity.java
+++ b/src/main/java/com/napzak/domain/store/core/entity/StoreEntity.java
@@ -90,4 +90,24 @@ public class StoreEntity {
 			photo(photo).
 			cover(cover).build();
 	}
+
+	public void setNickname(String nickname) {
+		this.nickname = nickname;
+	}
+
+	public void setRole(Role role) {
+		this.role = role;
+	}
+
+	public void setCover(String cover) {
+		this.cover = cover;
+	}
+
+	public void setPhoto(String photo) {
+		this.photo = photo;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
 }

--- a/src/main/java/com/napzak/global/external/s3/api/controller/FileApi.java
+++ b/src/main/java/com/napzak/global/external/s3/api/controller/FileApi.java
@@ -2,6 +2,7 @@ package com.napzak.global.external.s3.api.controller;
 
 import com.napzak.global.common.exception.dto.SuccessResponse;
 import com.napzak.global.external.s3.api.dto.ProductPresignedUrlFindAllResponse;
+import com.napzak.global.external.s3.api.dto.StorePresignedUrlFindAllResponse;
 import com.napzak.global.swagger.annotation.DisableSwaggerSecurity;
 
 import io.swagger.v3.oas.annotations.*;
@@ -19,15 +20,25 @@ import java.util.List;
 public interface FileApi {
 
 	@DisableSwaggerSecurity
-	@Operation(summary = "S3 Presigned URL 발급", description = "S3에 업로드할 presigned URL을 생성합니다.")
+	@Operation(summary = "상품 이미지 Presigned URL 발급", description = "상품 이미지 업로드를 위한 Presigned URL을 발급합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "Presigned URL 발급 성공",
 			content = @Content(schema = @Schema(implementation = ProductPresignedUrlFindAllResponse.class))),
-		@ApiResponse(responseCode = "400", description = "잘못된 요청 - productImages 리스트가 비어 있음")
+		@ApiResponse(responseCode = "400", description = "이미지 리스트가 비어있음")
 	})
 	@GetMapping("/product")
-	ResponseEntity<SuccessResponse<ProductPresignedUrlFindAllResponse>> generateAllPresignedUrls(
-		@Parameter(description = "업로드할 제품 이미지 리스트", required = true)
-		@RequestParam List<String> productImages
-	);
+	ResponseEntity<SuccessResponse<ProductPresignedUrlFindAllResponse>> generatePresignedUrlsForProduct(
+		@RequestParam List<String> productImages);
+
+	@DisableSwaggerSecurity
+	@Operation(summary = "상점 이미지 Presigned URL 발급", description = "상점 프로필/커버 업로드용 Presigned URL을 발급합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "201", description = "Presigned URL 발급 성공",
+			content = @Content(schema = @Schema(implementation = StorePresignedUrlFindAllResponse.class))),
+		@ApiResponse(responseCode = "400", description = "이미지 리스트가 비어있음")
+	})
+	@GetMapping("/stores")
+	ResponseEntity<SuccessResponse<StorePresignedUrlFindAllResponse>> generatePresignedUrlsForStore(
+		@RequestParam List<String> profileImages);
+
 }

--- a/src/main/java/com/napzak/global/external/s3/api/controller/FileController.java
+++ b/src/main/java/com/napzak/global/external/s3/api/controller/FileController.java
@@ -1,6 +1,7 @@
 package com.napzak.global.external.s3.api.controller;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.napzak.global.common.exception.dto.SuccessResponse;
 import com.napzak.global.external.s3.api.dto.ProductPresignedUrlFindAllResponse;
+import com.napzak.global.external.s3.api.dto.StorePresignedUrlFindAllResponse;
 import com.napzak.global.external.s3.api.service.FileService;
 import com.napzak.global.external.s3.exception.FileSuccessCode;
 
@@ -24,16 +26,26 @@ public class FileController implements FileApi {
 
 	@Override
 	@GetMapping("/product")
-	public ResponseEntity<SuccessResponse<ProductPresignedUrlFindAllResponse>> generateAllPresignedUrls(
+	public ResponseEntity<SuccessResponse<ProductPresignedUrlFindAllResponse>> generatePresignedUrlsForProduct(
 		@RequestParam List<String> productImages) {
 		if (productImages == null || productImages.isEmpty()) {
 			throw new IllegalArgumentException("productImages 리스트는 비어 있을 수 없습니다.");
 		}
-
-		ProductPresignedUrlFindAllResponse response = fileService.generateAllPresignedUrlsForProduct(productImages);
-
+		Map<String, String> urls = fileService.generateAllPresignedUrls(productImages, "product");
+		ProductPresignedUrlFindAllResponse response = ProductPresignedUrlFindAllResponse.from(urls);
 		return ResponseEntity.ok(
-			SuccessResponse.of(FileSuccessCode.PRESIGNED_URL_ISSUED, response)
-		);
+			SuccessResponse.of(FileSuccessCode.PRESIGNED_URL_ISSUED, response));
+	}
+
+	@GetMapping("/stores")
+	public ResponseEntity<SuccessResponse<StorePresignedUrlFindAllResponse>> generatePresignedUrlsForStore(
+		@RequestParam List<String> profileImages) {
+		if (profileImages == null || profileImages.isEmpty()) {
+			throw new IllegalArgumentException("productImages 리스트는 비어 있을 수 없습니다.");
+		}
+		Map<String, String> urls = fileService.generateAllPresignedUrls(profileImages, "store");
+		StorePresignedUrlFindAllResponse response = StorePresignedUrlFindAllResponse.from(urls);
+		return ResponseEntity.ok(
+			SuccessResponse.of(FileSuccessCode.PRESIGNED_URL_ISSUED, response));
 	}
 }

--- a/src/main/java/com/napzak/global/external/s3/api/dto/StorePresignedUrlFindAllResponse.java
+++ b/src/main/java/com/napzak/global/external/s3/api/dto/StorePresignedUrlFindAllResponse.java
@@ -1,0 +1,12 @@
+package com.napzak.global.external.s3.api.dto;
+
+import java.util.Map;
+
+public record StorePresignedUrlFindAllResponse(
+	Map<String, String> profilePresignedUrls
+) {
+	public static StorePresignedUrlFindAllResponse from(
+		Map<String, String> profilePresignedUrls) {
+		return new StorePresignedUrlFindAllResponse(profilePresignedUrls);
+	}
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #35 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
1. 상점 프로필 이미지용 Presigned URL 발급 API 추가
- GET /api/v1/presigned-url/stores
- @RequestParam으로 파일명 리스트(profileImages) 전달 시 S3 presigned-url 일괄 발급
- prefix는 store로 고정하여 S3 경로 구분

2. Presigned URL 생성 로직 리팩토링
- 중복 제거: FileService.generateAllPresignedUrls(List<String>, String) 공통 메서드로 통합
- 상품/상점 presigned-url 생성 시 prefix만 다르게 전달
- 기존 /product API에는 영향 없음

3. 상점 프로필 수정 및 조회 API 구현
- GET /api/v1/stores/modify/profile
- PUT /api/v1/stores/modify/profile

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
