### PR TITLE
[feat] #37 - 홈화면 추천상품 조회 api 리팩토링

### DIFF
--- a/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
+++ b/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
@@ -609,17 +609,15 @@ public class ProductController implements ProductApi {
 	public ResponseEntity<SuccessResponse<ProductRecommendListResponse>> getRecommendProducts(
 		@CurrentMember Long currentStoreId
 	) {
+		String nickname = productStoreFacade.getStoreNickname(currentStoreId);
 		List<Long> genreIds = productStoreFacade.getGenrePreferenceIds(currentStoreId);
 
 		ProductPagination pagination = productService.getHomeRecommendProducts(currentStoreId, genreIds);
 
 		Map<Long, Boolean> interestMap = fetchInterestMap(pagination, currentStoreId);
-		interestMap.putAll(fetchInterestMap(pagination, currentStoreId));
-
 		Map<Long, String> genreMap = fetchGenreMap(pagination);
-		genreMap.putAll(fetchGenreMap(pagination));
 
-		ProductRecommendListResponse productListResponse = ProductRecommendListResponse.from(pagination, interestMap,
+		ProductRecommendListResponse productListResponse = ProductRecommendListResponse.from(nickname, pagination, interestMap,
 			genreMap, currentStoreId);
 
 		return ResponseEntity.ok()
@@ -749,7 +747,6 @@ public class ProductController implements ProductApi {
 		}
 
 	}
-  
 
 	private Map<Long, Boolean> fetchInterestMap(ProductPagination pagination, Long storeId) {
 		List<Long> productIds = pagination.getProductList().stream()

--- a/src/main/java/com/napzak/domain/product/api/dto/response/ProductRecommendListResponse.java
+++ b/src/main/java/com/napzak/domain/product/api/dto/response/ProductRecommendListResponse.java
@@ -7,9 +7,11 @@ import com.napzak.domain.product.api.service.ProductPagination;
 import com.napzak.global.common.util.TimeUtils;
 
 public record ProductRecommendListResponse(
+	String nickname,
 	List<ProductBuyDto> productRecommendList
 ) {
 	public static ProductRecommendListResponse from(
+		String nickname,
 		ProductPagination pagination,
 		Map<Long, Boolean> interestMap,
 		Map<Long, String> genreMap,
@@ -27,6 +29,6 @@ public record ProductRecommendListResponse(
 				);
 			}).toList();
 
-		return new ProductRecommendListResponse(productDtos);
+		return new ProductRecommendListResponse(nickname, productDtos);
 	}
 }

--- a/src/main/java/com/napzak/domain/product/core/ProductRepositoryCustom.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductRepositoryCustom.java
@@ -22,8 +22,12 @@ public interface ProductRepositoryCustom {
 	List<ProductEntity> findProductsBySortOptionExcludingStoreId(
 		OrderSpecifier<?> orderSpecifier, int size, TradeType tradeType, long storeId);
 
-	List<ProductEntity> findProductsByGenreAndTradeTypeExcludingStoreId(Long genreId, Long excludeStoreId,
-		TradeType tradeType, int limit);
+	List<ProductEntity> findProductsByGenresAndTradeTypesExcludingStoreId(
+		List<Long> genreIds,
+		List<TradeType> tradeTypes,
+		Long excludeStoreId,
+		int limit
+	);
 
 	List<ProductEntity> findLatestProductsExcludingStoreId(Long excludeStoreId, TradeType tradeType, int limit);
 

--- a/src/main/java/com/napzak/domain/product/core/ProductRepositoryCustomImpl.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductRepositoryCustomImpl.java
@@ -142,22 +142,22 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
 		return count != null ? count : 0L;
 	}
 
-	/**
-	 * 본인 상품 제외 특정 장르의 상품을 가져오기 (SELL 또는 BUY)
-	 */
 	@Override
-	public List<ProductEntity> findProductsByGenreAndTradeTypeExcludingStoreId(Long genreId, Long excludeStoreId,
-		TradeType tradeType, int limit) {
-		return queryFactory
-			.selectFrom(productEntity)
+	public List<ProductEntity> findProductsByGenresAndTradeTypesExcludingStoreId(
+		List<Long> genreIds,
+		List<TradeType> tradeTypes,
+		Long excludeStoreId,
+		int limit
+	) {
+		return queryFactory.selectFrom(productEntity)
 			.where(
-				productEntity.genreId.eq(genreId),               // 특정 장르 ID
-				productEntity.storeId.ne(excludeStoreId),        // 본인 상품 제외
-				productEntity.tradeType.eq(tradeType),           // SELL 또는 BUY 필터링
-				productEntity.tradeStatus.eq(TradeStatus.BEFORE_TRADE)  // 거래 가능 상태
+				productEntity.genreId.in(genreIds),
+				productEntity.tradeType.in(tradeTypes),
+				productEntity.storeId.ne(excludeStoreId),
+				productEntity.tradeStatus.eq(TradeStatus.BEFORE_TRADE)
 			)
-			.orderBy(productEntity.createdAt.desc())             // 최신순 정렬
-			.limit(limit)                                   // 원하는 개수만큼 조회
+			.orderBy(productEntity.createdAt.desc())
+			.limit(limit)
 			.fetch();
 	}
 

--- a/src/main/java/com/napzak/domain/product/core/ProductRetriever.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductRetriever.java
@@ -1,10 +1,7 @@
 package com.napzak.domain.product.core;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -102,273 +99,117 @@ public class ProductRetriever {
 		return productRepository.countProductsByFilters(isOnSale, isUnopened, genreIds, tradeType);
 	}
 
-	/**
-	 * 홈화면용 추천상품을 조회:
-	 *  - 선호 장르(각각 SELL2, BUY2) 모으기
-	 *  - 부족하면 fallback 장르, 최신 상품
-	 *  - 최종 2SELL+2BUY=4개
-	 *  - 장르를 최대한 다르게 구성(겹치지 않게)
-	 */
 	@Transactional(readOnly = true)
 	public List<Product> retrieveRecommendedProducts(Long storeId, List<Long> preferredGenres) {
-		// 1) 우선 선호 장르에서 최대한 수집
-		List<ProductEntity> collected = collectFromPreferredGenres(storeId, preferredGenres);
+		// 추천 상품 조회 흐름:
+		// 1. 관심 장르에서 SELL/BUY 상품 수집 (1쿼리)
+		// 2. 부족하면 fallback 장르에서 추가 수집 (1쿼리)
+		// 3. 그래도 부족하면 최신 SELL 2개 + BUY 2개 수집 (2쿼리)
+		// => 2SELL + 2BUY 조합을 항상 보장하며, 장르 다양성을 최우선으로 고려
 
-		// 2) 2SELL+2BUY가 부족하면 fallback 장르에서 추가 수집
-		if (!isEnoughForSellBuy(collected, 2, 2)) {
-			collected = fillShortageWithFallback(storeId, collected, 2, 2);
-		}
+		List<ProductEntity> candidates = new ArrayList<>();
 
-		// 3) 여전히 부족하면 최신 상품
-		if (!isEnoughForSellBuy(collected, 2, 2)) {
-			collected = fillShortageWithLatest(storeId, collected, 2, 2);
-		}
+		boolean preferredGenreSufficient = false;
 
-		// 4) 이제 collected 내에서 2SELL+2BUY=4개 조합을 모두 탐색,
-		//    "서로 다른 장르를 최대화"하는 조합을 고른다.
-		List<ProductEntity> best4 = pickBestFourMaxDistinctGenre(collected, 2, 2);
-
-		// 5) 만약 정말로 2SELL+2BUY가 불가능하면(리턴이 빈 리스트),
-		//    요구사항에 따라 반환값 변경 가능
-		//    우선은 "빈 리스트" 반환
-		if (best4.isEmpty()) {
-			return List.of();
-		}
-
-		// 6) SELL-BUY-SELL-BUY 순으로 정렬
-		best4 = reorderSellBuy(best4);
-
-		// 7) 엔티티 -> DTO 변환
-		return best4.stream().map(Product::fromEntity).toList();
-	}
-
-	// ============================================================
-	// 1) 선호장르에서 수집: 장르마다 SELL 최대2, BUY 최대2
-	// ============================================================
-	private List<ProductEntity> collectFromPreferredGenres(Long storeId, List<Long> preferredGenres) {
-		List<ProductEntity> all = new ArrayList<>();
-		for (Long genreId : preferredGenres) {
-			// SELL 최대 2
-			List<ProductEntity> sells = productRepository.findProductsByGenreAndTradeTypeExcludingStoreId(
-				genreId, storeId, TradeType.SELL, 2
+		// [1] 선호 장르가 있을 경우만 조회 시도
+		if (preferredGenres != null && !preferredGenres.isEmpty()) {
+			List<ProductEntity> productsFromPreferredGenres = productRepository.findProductsByGenresAndTradeTypesExcludingStoreId(
+				preferredGenres,
+				List.of(TradeType.SELL, TradeType.BUY),
+				storeId,
+				preferredGenres.size() * 4
 			);
-			// BUY 최대 2
-			List<ProductEntity> buys = productRepository.findProductsByGenreAndTradeTypeExcludingStoreId(
-				genreId, storeId, TradeType.BUY, 2
+			candidates.addAll(productsFromPreferredGenres);
+
+			if (isEnoughForSellBuy(candidates, 2, 2)) {
+				preferredGenreSufficient = true;
+			}
+		}
+
+		// [2] fallback 장르 조회는 선호 장르가 없거나 부족할 때만 수행
+		if (!preferredGenreSufficient) {
+			List<ProductEntity> productsFromFallbackGenres = productRepository.findProductsByGenresAndTradeTypesExcludingStoreId(
+				FALLBACK_GENRES,
+				List.of(TradeType.SELL, TradeType.BUY),
+				storeId,
+				FALLBACK_GENRES.size() * 4
 			);
-			all.addAll(sells);
-			all.addAll(buys);
-		}
-		return deduplicate(all);
-	}
+			candidates = mergeWithoutDuplicates(candidates, productsFromFallbackGenres);
 
-	// ============================================================
-	// 2) fallback 장르에서 부족분 수집 (방법: 장르마다 SELL2, BUY2)
-	// ============================================================
-	private List<ProductEntity> fillShortageWithFallback(
-		Long storeId,
-		List<ProductEntity> collected,
-		int needSell,
-		int needBuy
-	) {
-		int shortageSell = needSell - countSell(collected);
-		int shortageBuy = needBuy - countBuy(collected);
-
-		// 이미 충족이면 그대로
-		if (shortageSell <= 0 && shortageBuy <= 0) {
-			return collected;
+			if (isEnoughForSellBuy(candidates, 2, 2)) {
+				log.info("[HomeRecommend] fallback까지만으로 추천 상품 조합 충족");
+			}
 		}
 
-		// fallback 장르 전부에서 SELL2 + BUY2
-		List<ProductEntity> fallbackAll = new ArrayList<>();
-		for (Long genreId : FALLBACK_GENRES) {
-			List<ProductEntity> sells = productRepository.findProductsByGenreAndTradeTypeExcludingStoreId(
-				genreId, storeId, TradeType.SELL, 2
-			);
-			List<ProductEntity> buys = productRepository.findProductsByGenreAndTradeTypeExcludingStoreId(
-				genreId, storeId, TradeType.BUY, 2
-			);
-			fallbackAll.addAll(sells);
-			fallbackAll.addAll(buys);
-		}
+		// [3] 여전히 부족하면 최신 SELL 2개 + BUY 2개 보완
+		int shortageSell = 2 - countTradeType(candidates, TradeType.SELL);
+		int shortageBuy = 2 - countTradeType(candidates, TradeType.BUY);
 
-		List<ProductEntity> merged = mergeWithoutDuplicates(collected, fallbackAll);
-		return merged;
-	}
-
-	// ============================================================
-	// 3) 최신 상품으로 부족분 보충 (SELL/BUY 각각 shortage만큼)
-	//    - 여기서는 "모든 장르"를 최신순으로 보되,
-	//      tradeType에 따라 shortage만큼
-	// ============================================================
-	private List<ProductEntity> fillShortageWithLatest(
-		Long storeId,
-		List<ProductEntity> collected,
-		int needSell,
-		int needBuy
-	) {
-		int shortageSell = needSell - countSell(collected);
-		int shortageBuy = needBuy - countBuy(collected);
-
-		if (shortageSell <= 0 && shortageBuy <= 0) {
-			return collected;
-		}
-
-		// 최신 SELL
-		List<ProductEntity> additionalSells = new ArrayList<>();
 		if (shortageSell > 0) {
-			// "최신 SELL"만 shortageSell개
-			additionalSells = productRepository.findLatestProductsExcludingStoreId(
-				storeId,
-				TradeType.SELL,
-				shortageSell
+			List<ProductEntity> latestSellProducts = productRepository.findLatestProductsExcludingStoreId(
+				storeId, TradeType.SELL, 2
 			);
+			candidates = mergeWithoutDuplicates(candidates, latestSellProducts);
 		}
 
-		// 최신 BUY
-		List<ProductEntity> additionalBuys = new ArrayList<>();
 		if (shortageBuy > 0) {
-			additionalBuys = productRepository.findLatestProductsExcludingStoreId(
-				storeId,
-				TradeType.BUY,
-				shortageBuy
+			List<ProductEntity> latestBuyProducts = productRepository.findLatestProductsExcludingStoreId(
+				storeId, TradeType.BUY, 2
 			);
+			candidates = mergeWithoutDuplicates(candidates, latestBuyProducts);
 		}
 
-		// 합치기
-		List<ProductEntity> merged = mergeWithoutDuplicates(collected, additionalSells);
-		merged = mergeWithoutDuplicates(merged, additionalBuys);
-		return merged;
+		// [4] 최적 조합 선택 (장르 중복 허용 포함)
+		List<ProductEntity> bestFourProducts = pickBestFourAllowingGenreOverlap(candidates, 2, 2);
+		if (bestFourProducts.isEmpty()) return List.of();
+
+		// [5] 정렬 후 DTO 변환
+		return convertToProductList(reorderSellBuy(bestFourProducts));
 	}
 
-	// ============================================================
-	// 4) pickBestFourMaxDistinctGenre()
-	//    - collected 내에서 2SELL+2BUY=4개를 만드는 모든 조합 탐색
-	//    - "서로 다른 장르 수"가 최대가 되는 조합을 선택
-	//    - 여러 개라면 임의로 하나 선택 (혹은 다른 우선순위가 있다면 추가)
-	// ============================================================
-	private List<ProductEntity> pickBestFourMaxDistinctGenre(
-		List<ProductEntity> collected,
-		int needSell,
-		int needBuy
-	) {
-		// 우선 "2SELL+2BUY"를 만족하는 4개 부분집합을 전부 찾는다.
-		// 그중에서 "장르 수"가 최대인 조합을 반환.
+	private List<ProductEntity> pickBestFourAllowingGenreOverlap(List<ProductEntity> productList, int needSell, int needBuy) {
+		if (productList.size() < 4) return List.of();
 
-		if (collected.size() < 4) {
-			return Collections.emptyList();
-		}
-
-		// 부분집합을 찾기 위해, 간단히 "nC4"를 전수조사(브루트포스)하자.
-		// n이 20 이하 정도면 충분히 빠름.
 		List<ProductEntity> best = new ArrayList<>();
 		int maxDistinctGenres = -1;
 
-		List<List<ProductEntity>> allCombinations = combinationsOfSize(collected, 4);
-		for (List<ProductEntity> combo : allCombinations) {
+		List<List<ProductEntity>> combinations = combinationsOfSize(productList, 4);
+		for (List<ProductEntity> combo : combinations) {
 			long sellCount = combo.stream().filter(p -> p.getTradeType() == TradeType.SELL).count();
 			long buyCount = combo.stream().filter(p -> p.getTradeType() == TradeType.BUY).count();
 
 			if (sellCount == needSell && buyCount == needBuy) {
-				// 장르 중복 확인
-				long distinctGenreCount = combo.stream()
-					.map(ProductEntity::getGenreId)
-					.distinct()
-					.count();
-
+				long distinctGenreCount = combo.stream().map(ProductEntity::getGenreId).distinct().count();
 				if (distinctGenreCount > maxDistinctGenres) {
-					maxDistinctGenres = (int)distinctGenreCount;
-					best = combo; // 이 조합을 채택
+					maxDistinctGenres = (int) distinctGenreCount;
+					best = combo;
 				}
 			}
 		}
 
-		// 만약 아무 조합도 없으면 빈 리스트
-		// 있으면 best 반환
+		// fallback: 장르 중복되더라도 조건 만족 조합 하나라도 리턴
+		if (best.isEmpty()) {
+			for (List<ProductEntity> combo : combinations) {
+				long sellCount = combo.stream().filter(p -> p.getTradeType() == TradeType.SELL).count();
+				long buyCount = combo.stream().filter(p -> p.getTradeType() == TradeType.BUY).count();
+				if (sellCount == needSell && buyCount == needBuy) {
+					return combo;
+				}
+			}
+		}
+
 		return best;
 	}
 
-	// ============================================================
-	// 5) SELL-BUY-SELL-BUY 순서로 재정렬
-	//    (이미 2SELL,2BUY라고 가정)
-	// ============================================================
-	private List<ProductEntity> reorderSellBuy(List<ProductEntity> four) {
-		if (four.size() < 4)
-			return four; // 혹은 그냥 그대로
-
-		// SELL만 추출
-		List<ProductEntity> sells = four.stream()
-			.filter(p -> p.getTradeType() == TradeType.SELL)
-			.collect(Collectors.toList());
-
-		// BUY만 추출
-		List<ProductEntity> buys = four.stream()
-			.filter(p -> p.getTradeType() == TradeType.BUY)
-			.collect(Collectors.toList());
-
-		List<ProductEntity> result = new ArrayList<>();
-		for (int i = 0; i < Math.max(sells.size(), buys.size()); i++) {
-			if (i < sells.size())
-				result.add(sells.get(i));
-			if (i < buys.size())
-				result.add(buys.get(i));
-		}
-		return result;
-	}
-
-	// ============================================================
-	// [조합] nCk 구하기 (브루트포스)
-	// ============================================================
-	private List<List<ProductEntity>> combinationsOfSize(List<ProductEntity> list, int k) {
-		List<List<ProductEntity>> result = new ArrayList<>();
-		backtrack(list, 0, k, new ArrayList<>(), result);
-		return result;
-	}
-
-	private void backtrack(
-		List<ProductEntity> list,
-		int startIndex,
-		int k,
-		List<ProductEntity> current,
-		List<List<ProductEntity>> result
-	) {
-		if (current.size() == k) {
-			result.add(new ArrayList<>(current));
-			return;
-		}
-		for (int i = startIndex; i < list.size(); i++) {
-			current.add(list.get(i));
-			backtrack(list, i + 1, k, current, result);
-			current.remove(current.size() - 1);
-		}
-	}
-
-	// ============================================================
-	// 기타 보조 메서드
-	// ============================================================
 	private boolean isEnoughForSellBuy(List<ProductEntity> list, int needSell, int needBuy) {
-		return countSell(list) >= needSell && countBuy(list) >= needBuy;
+		return countTradeType(list, TradeType.SELL) >= needSell && countTradeType(list, TradeType.BUY) >= needBuy;
 	}
 
-	private int countSell(List<ProductEntity> list) {
-		return (int)list.stream().filter(p -> p.getTradeType() == TradeType.SELL).count();
-	}
-
-	private int countBuy(List<ProductEntity> list) {
-		return (int)list.stream().filter(p -> p.getTradeType() == TradeType.BUY).count();
-	}
-
-	private List<ProductEntity> deduplicate(List<ProductEntity> list) {
-		// ID 기준 중복 제거
-		Map<Long, ProductEntity> map = new LinkedHashMap<>();
-		for (ProductEntity p : list) {
-			map.put(p.getId(), p);
-		}
-		return new ArrayList<>(map.values());
+	private int countTradeType(List<ProductEntity> list, TradeType type) {
+		return (int) list.stream().filter(p -> p.getTradeType() == type).count();
 	}
 
 	private List<ProductEntity> mergeWithoutDuplicates(List<ProductEntity> base, List<ProductEntity> extra) {
-		// base + extra 중복 제거
 		Set<Long> baseIds = base.stream().map(ProductEntity::getId).collect(Collectors.toSet());
 		List<ProductEntity> merged = new ArrayList<>(base);
 		for (ProductEntity e : extra) {
@@ -377,5 +218,38 @@ public class ProductRetriever {
 			}
 		}
 		return merged;
+	}
+
+	private List<ProductEntity> reorderSellBuy(List<ProductEntity> four) {
+		List<ProductEntity> sells = four.stream().filter(p -> p.getTradeType() == TradeType.SELL).toList();
+		List<ProductEntity> buys = four.stream().filter(p -> p.getTradeType() == TradeType.BUY).toList();
+		List<ProductEntity> res = new ArrayList<>();
+		for (int i = 0; i < 2; i++) {
+			if (i < sells.size()) res.add(sells.get(i));
+			if (i < buys.size()) res.add(buys.get(i));
+		}
+		return res;
+	}
+
+	private List<Product> convertToProductList(List<ProductEntity> entities) {
+		return entities.stream().map(Product::fromEntity).toList();
+	}
+
+	private List<List<ProductEntity>> combinationsOfSize(List<ProductEntity> list, int k) {
+		List<List<ProductEntity>> result = new ArrayList<>();
+		backtrack(list, 0, k, new ArrayList<>(), result);
+		return result;
+	}
+
+	private void backtrack(List<ProductEntity> list, int idx, int k, List<ProductEntity> curr, List<List<ProductEntity>> res) {
+		if (curr.size() == k) {
+			res.add(new ArrayList<>(curr));
+			return;
+		}
+		for (int i = idx; i < list.size(); i++) {
+			curr.add(list.get(i));
+			backtrack(list, i + 1, k, curr, res);
+			curr.remove(curr.size() - 1);
+		}
 	}
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #37 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 홈 추천상품 조회 dto 기능명세에 맞게 수정
- 홈화면 추천상품 조회 api 리팩토링

# 📦 PR 설명: 홈 추천 상품 조회 리팩토링

## 1. 리팩토링 필요성

- 기존 추천 로직은 관심 장르별로 SELL/BUY를 별도로 다중 조회하여 **불필요한 다수 쿼리(N\*2)** 발생
- 관심 장르 상품이 충분한 경우에도 fallback 장르를 무조건 조회하여 **불필요한 조회 비용** 발생
- 선호 장르가 없는 경우 fallback이나 최신 상품으로 자연스럽게 넘어가지 못하는 **예외 케이스 미처리**
- 2SELL + 2BUY 조합 실패 시 결과가 없는 경우가 발생하여 **UI/UX 문제가 발생할 위험 존재**
- 전체 코드 흐름이 명확하지 않아 유지보수성과 가독성 저하

---

## 2. 전후 변화 비교

| 항목 | 리팩토링 전 | 리팩토링 후 |
|:---|:---|:---|
| 관심 장르 조회 | 장르별 개별 쿼리 (N\*2) | 전체 일괄 조회 (1쿼리) |
| fallback 조회 | 항상 실행 | 부족할 때만 실행 |
| 최신 상품 조회 | 부족 수만큼 동적 조회 | 무조건 SELL2 + BUY2 조회 |
| 조합 실패 대응 | 실패 시 빈 결과 | 장르 중복 허용해 조합 완성 보장 |
| 선호 장르 없음 처리 | 없음 | fallback → 최신 상품으로 자연스러운 전환 |
| 코드 구조 | 흐름 불명확, 추측 필요 | 관심 → fallback → 최신 상품, 단계별 명확화 |
| 네이밍 | 줄임말 위주 | 의미 명확한 네이밍 |
| 주석 | 없음 | 단계별 흐름 설명 주석 추가 |

---

## 3. 구현 방법

- 관심 장르 상품을 **한 번에 통합 조회**하여 충분하면 fallback을 생략
- fallback 장르 상품은 **관심 장르가 부족할 때만** 조회
- fallback까지 부족하면 **최신 SELL 2개 + BUY 2개**를 무조건 추가 조회
- 가능한 경우 **장르 다양성이 높은 조합**을 선택하고, 불가능하면 **장르 중복 허용**하여 조합 충족
- **2SELL + 2BUY 조합을 항상 보장**하는 로직으로 변경
- 주석 추가 및 함수 네이밍 개선하여 가독성과 유지보수성 향상
- 상황별 분기 로직을 통해 쿼리 발생 패턴을 명확하게 제어

---

## 4. 성능 개선 정도

| 항목 | 리팩토링 전 | 리팩토링 후 |
|:---|:---|:---|
| 관심 장르 상품 조회 쿼리 수 | N\*2 쿼리 (장르별 SELL/BUY 각각 조회) | 1쿼리 (장르+타입 한번에 조회) |
| fallback, 최신 상품 조회 쿼리 | 무조건 실행 | 필요할 때만 실행 |
| 전체 추천 쿼리 수 | 10~20 쿼리 발생 가능성 | **최대 4쿼리**로 고정 가능 (관심 1 + fallback 1 + 최신 SELL/BUY 2) |

---

## ✅ 요약

- **쿼리 최적화** + **예외 케이스 대응** + **추천 품질 보장** + **코드 가독성 및 유지보수성 강화**

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
## postman test
<img width="728" alt="image" src="https://github.com/user-attachments/assets/fda6fd0d-e3f3-43b6-91ec-34b195a4c57c" />

정상적으로 nickname 포함 응답 반환

## 동일 조건 하에서 실험 결과
### AS-IS - 쿼리 24개 발생
![image](https://github.com/user-attachments/assets/74f2183f-0164-44c1-ae7d-3ca4d05573c9)

### TO-BE - 쿼리 8개 발생
![image](https://github.com/user-attachments/assets/b5b02598-6558-455f-bd50-3b4d2217ff81)

**=>쿼리 개수 3분의 1 감소**

### 상황별 발생 쿼리 개수
![image](https://github.com/user-attachments/assets/b9030885-9809-4fe6-b497-a67e9f9a22ad)

- 선호 장르가 없을 경우 : 7개

![image](https://github.com/user-attachments/assets/d8f0647b-1ed4-4188-ade1-0d8186a4f808)

- 선호 장르에서 추천 상품 조건을 모두 충족시킨 경우 : 6개

![image](https://github.com/user-attachments/assets/52eb22db-a436-4d3b-8cbb-6d84e5a5f466)

- 선호 장르 + fallback 장르에서 조합해서 추천 상품을 조합한 경우 : 8개

### => 쿼리 개수 최소 6개, 최대 8개로 오차 최소화 및 성능 개선

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
브랜치를 착각해서 이전 브랜치에 같이 작업했는데 양해 부탁드립니다ㅜㅜ