### PR TITLE
[feat] #50 - 애플 소셜로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # 예외
 !gradle/wrapper/gradle-wrapper.jar
 
+#로컬 테스트용 개인 private-key
+src/main/resources/napzak-local.p12
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    //WebClient
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 jar {

--- a/src/main/java/com/napzak/domain/store/api/exception/StoreErrorCode.java
+++ b/src/main/java/com/napzak/domain/store/api/exception/StoreErrorCode.java
@@ -16,6 +16,7 @@ public enum StoreErrorCode implements BaseErrorCode {
 	INVALID_GENRE_PREFERENCE_COUNT(HttpStatus.BAD_REQUEST, "선호 장르 리스트는 최대 4개까지 입력할 수 있습니다."),
 	DUPLICATE_GENRE_PREFERENCES(HttpStatus.BAD_REQUEST, "선호 장르 리스트에 중복된 값이 있습니다."),
 	NICKNAME_CONTAINS_SLANG(HttpStatus.BAD_REQUEST, "욕설이나 비속어를 사용할 수 없어요."),
+	SOCIAL_TYPE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인 타입입니다."),
 
 	/*
 	404 Not Found

--- a/src/main/java/com/napzak/domain/store/api/service/LoginService.java
+++ b/src/main/java/com/napzak/domain/store/api/service/LoginService.java
@@ -1,5 +1,7 @@
 package com.napzak.domain.store.api.service;
 
+import com.napzak.domain.store.api.exception.StoreErrorCode;
+import com.napzak.global.auth.client.service.AppleSocialService;
 import com.napzak.global.auth.client.service.GoogleSocialService;
 
 import org.springframework.stereotype.Service;
@@ -11,6 +13,7 @@ import com.napzak.domain.store.core.vo.Store;
 import com.napzak.global.auth.client.dto.StoreSocialInfoResponse;
 import com.napzak.global.auth.client.dto.StoreSocialLoginRequest;
 import com.napzak.global.auth.client.service.SocialService;
+import com.napzak.global.common.exception.NapzakException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +28,7 @@ public class LoginService {
 	private final AuthenticationService authenticationService;
 	private final StoreService storeService;
 	private final GoogleSocialService googleSocialService;
+	private final AppleSocialService appleSocialService;
 
 	@Transactional
 	public LoginSuccessResponse login(
@@ -59,7 +63,8 @@ public class LoginService {
 		return switch (socialType) {
 			case KAKAO -> kakaoSocialService;
 			case GOOGLE -> googleSocialService;
-			default -> throw new RuntimeException();
+			case APPLE -> appleSocialService;
+			default -> throw new NapzakException(StoreErrorCode.SOCIAL_TYPE_NOT_SUPPORTED);
 		};
 	}
 

--- a/src/main/java/com/napzak/global/auth/client/apple/dto/ApplePublicKeyDto.java
+++ b/src/main/java/com/napzak/global/auth/client/apple/dto/ApplePublicKeyDto.java
@@ -1,0 +1,13 @@
+package com.napzak.global.auth.client.apple.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ApplePublicKeyDto{
+	private String kty;
+	private String kid;
+	private String use;
+	private String alg;
+	private String n;
+	private String e;
+}

--- a/src/main/java/com/napzak/global/auth/client/apple/dto/ApplePublicKeyResponse.java
+++ b/src/main/java/com/napzak/global/auth/client/apple/dto/ApplePublicKeyResponse.java
@@ -1,0 +1,13 @@
+package com.napzak.global.auth.client.apple.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ApplePublicKeyResponse {
+	private List<ApplePublicKeyDto> keys;
+}
+

--- a/src/main/java/com/napzak/global/auth/client/apple/dto/AppleTokenResponseDto.java
+++ b/src/main/java/com/napzak/global/auth/client/apple/dto/AppleTokenResponseDto.java
@@ -1,0 +1,19 @@
+package com.napzak.global.auth.client.apple.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+
+@Getter
+public class AppleTokenResponseDto {
+	@JsonProperty("access_token")
+	private String accessToken;
+	@JsonProperty("token_type")
+	private String tokenType;
+	@JsonProperty("expires_in")
+	private String expiresIn;
+	@JsonProperty("refresh_token")
+	private String refreshToken;
+	@JsonProperty("id_token")
+	private String idToken;
+}

--- a/src/main/java/com/napzak/global/auth/client/exception/OAuthErrorCode.java
+++ b/src/main/java/com/napzak/global/auth/client/exception/OAuthErrorCode.java
@@ -16,6 +16,13 @@ public enum OAuthErrorCode implements BaseErrorCode {
  	*/
 	O_AUTH_TOKEN_ERROR(HttpStatus.UNAUTHORIZED, "OAuth 인증에 접근할 수 없습니다."),
 	GET_INFO_ERROR(HttpStatus.UNAUTHORIZED, "사용자의 정보를 가져올 수 없습니다."),
+	INVALID_APPLE_ID_TOKEN(HttpStatus.UNAUTHORIZED, "일치하는 public key를 찾을 수 없습니다."),
+
+	/*
+	500 INTERNAL SERVER ERROR
+	 */
+	APPLE_PUBLIC_KEY_EXTRACTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "public key 추출이 실패하였습니다."),
+	APPLE_PRIVATE_KEY_GENERATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "private key 생성에 실패하였습니다.")
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/napzak/global/auth/client/service/AppleSocialService.java
+++ b/src/main/java/com/napzak/global/auth/client/service/AppleSocialService.java
@@ -1,0 +1,131 @@
+package com.napzak.global.auth.client.service;
+
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.http.HttpHeaders;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import com.napzak.domain.store.core.entity.enums.SocialType;
+import com.napzak.global.auth.client.apple.dto.ApplePublicKeyDto;
+import com.napzak.global.auth.client.apple.dto.ApplePublicKeyResponse;
+import com.napzak.global.auth.client.apple.dto.AppleTokenResponseDto;
+import com.napzak.global.auth.client.dto.StoreSocialInfoResponse;
+import com.napzak.global.auth.client.dto.StoreSocialLoginRequest;
+import com.napzak.global.auth.client.exception.OAuthErrorCode;
+import com.napzak.global.common.exception.NapzakException;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AppleSocialService implements SocialService{
+
+	private static final long THIRTY_DAYS_MS = 30L * 24 * 60 * 60 * 1000;
+
+	@Value("${spring.security.oauth2.client.registration.apple.client-id}")
+	private String clientId;
+
+	@Value("${spring.security.oauth2.client.registration.apple.client-secret}")
+	private String clientSecret;
+
+	@Value("${spring.security.oauth2.apple.iss}")
+	private String teamId;
+
+	@Value("${spring.security.oauth2.apple.private-key}")
+	private String privateKey;
+
+	@Override
+	public StoreSocialInfoResponse login(String authorizationCode, StoreSocialLoginRequest request) {
+		AppleTokenResponseDto appleTokenResponse = getAppleToken(authorizationCode);
+		return getStore(appleTokenResponse);
+	}
+
+	public AppleTokenResponseDto getAppleToken(String authorizationCode) {
+		WebClient webClient = WebClient.builder()
+			.baseUrl("https://appleid.apple.com")
+			.defaultHeader(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded;charset=utf-8")
+			.build();
+
+		try {
+			return webClient.post()
+				.uri(uriBuilder -> uriBuilder.path("/auth/token")
+					.queryParam("grant_type", "authorization_code")
+					.queryParam("client_id", clientId)
+					.queryParam("client_secret", makeClientSecretToken())
+					.queryParam("code", authorizationCode)
+					.build())
+				.retrieve()
+				.bodyToMono(AppleTokenResponseDto.class)
+				.block();
+		} catch (WebClientResponseException e) {
+			log.error("[애플로그인 실패]: " + e.getResponseBodyAsString(), e);
+			throw e;
+		}
+	}
+
+	public StoreSocialInfoResponse getStore(AppleTokenResponseDto appleTokenResponseDto) {
+		PublicKeyFinder publicKeyFinder = new PublicKeyFinder(getApplePublicKeyList());
+
+		Claims claims = Jwts.parserBuilder()
+			.setSigningKeyResolver(publicKeyFinder)
+			.build()
+			.parseClaimsJws(appleTokenResponseDto.getIdToken())
+			.getBody();
+
+		StoreSocialInfoResponse storeSocialInfoResponse = StoreSocialInfoResponse.of(claims.getSubject(),
+			SocialType.APPLE);
+		return storeSocialInfoResponse;
+	}
+
+	private List<ApplePublicKeyDto> getApplePublicKeyList() {
+		WebClient webClient = WebClient.builder()
+			.baseUrl("https://appleid.apple.com")
+			.build();
+
+		ApplePublicKeyResponse applePublicKeyResponse = webClient.get()
+			.uri("/auth/keys")
+			.retrieve()
+			.bodyToMono(ApplePublicKeyResponse.class)
+			.block();
+
+		return applePublicKeyResponse.getKeys();
+	}
+
+	private String makeClientSecretToken() {
+		String token = Jwts.builder()
+			.setSubject(clientId)
+			.setIssuer(teamId)
+			.setIssuedAt(new Date())
+			.setExpiration(new Date(System.currentTimeMillis() + THIRTY_DAYS_MS))
+			.setAudience("https://appleid.apple.com")
+			.setHeaderParam("kid", clientSecret)
+			.signWith(getPrivateKey(), SignatureAlgorithm.ES256)
+			.compact();
+
+		return token;
+	}
+
+	private PrivateKey getPrivateKey() {
+		try {
+			byte[] privateKeyBytes = Decoders.BASE64.decode(privateKey);
+			PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(privateKeyBytes);
+			KeyFactory keyFactory = KeyFactory.getInstance("EC");
+			return keyFactory.generatePrivate(keySpec);
+		} catch (Exception e) {
+			throw new NapzakException(OAuthErrorCode.APPLE_PRIVATE_KEY_GENERATE_FAILED);
+		}
+	}
+}

--- a/src/main/java/com/napzak/global/auth/client/service/PublicKeyFinder.java
+++ b/src/main/java/com/napzak/global/auth/client/service/PublicKeyFinder.java
@@ -1,0 +1,57 @@
+package com.napzak.global.auth.client.service;
+
+import java.math.BigInteger;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.spec.KeySpec;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+
+import com.napzak.global.auth.client.apple.dto.ApplePublicKeyDto;
+import com.napzak.global.auth.client.exception.OAuthErrorCode;
+import com.napzak.global.common.exception.NapzakException;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.SigningKeyResolverAdapter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class PublicKeyFinder extends SigningKeyResolverAdapter {
+
+	private final List<ApplePublicKeyDto> applePublicKeyList;
+
+	@Override
+	public Key resolveSigningKey(JwsHeader header, Claims claims) {
+		return findKey(header);
+	}
+
+	@Override
+	public Key resolveSigningKey(JwsHeader header, String plaintext) {
+		return findKey(header);
+	}
+
+	private Key findKey(JwsHeader header) {
+		Optional<ApplePublicKeyDto> optionalPublicKey = applePublicKeyList.stream()
+			.filter(applePublicKey -> applePublicKey.getKid().equals(header.getKeyId()))
+			.findFirst();
+
+		if (optionalPublicKey.isEmpty()) {
+			throw new NapzakException(OAuthErrorCode.INVALID_APPLE_ID_TOKEN);
+		}
+
+		ApplePublicKeyDto publicKey = optionalPublicKey.get();
+
+		try {
+			BigInteger n = new BigInteger(1, Base64.getUrlDecoder().decode(publicKey.getN()));
+			BigInteger e = new BigInteger(1, Base64.getUrlDecoder().decode(publicKey.getE()));
+			KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+			KeySpec keySpec = new RSAPublicKeySpec(n, e);
+			return keyFactory.generatePublic(keySpec);
+		} catch (Exception error) {
+			throw new NapzakException(OAuthErrorCode.APPLE_PUBLIC_KEY_EXTRACTION_FAILED);
+		}
+	}
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #50

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
애플 소셜로그인 구현하였습니다. 
auth token을 얻은 후 로직은 카카오, 구글과 같습니다.
배포섭에서도 동작하련지.. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="683" alt="image" src="https://github.com/user-attachments/assets/b4e0a5f7-7b1b-4849-9984-733f583764f3" />


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
스크린샷에 refresh token이 같이 반환이 안되고 있길래 
함께 반환하도록 수정하여 #52 번 pr 올렸습니다~ 
