### PR TITLE
[feat] #60 - access token을 직접 입력받아 로그인하는 api 추가

### DIFF
--- a/src/main/java/com/napzak/domain/store/api/controller/StoreController.java
+++ b/src/main/java/com/napzak/domain/store/api/controller/StoreController.java
@@ -99,6 +99,26 @@ public class StoreController implements StoreApi {
 			.body(SuccessResponse.of(StoreSuccessCode.LOGIN_SUCCESS, successResponse));
 	}
 
+
+	@PostMapping("/login/kakao")
+	public ResponseEntity<SuccessResponse<LoginSuccessResponse>> loginWithKakaoAccessToken(
+		@RequestParam("accessToken") String accessToken,
+		@RequestBody StoreSocialLoginRequest storeSocialLoginRequest
+	) {
+		LoginSuccessResponse loginSuccessResponse = loginService.loginWithAccessToken(accessToken, storeSocialLoginRequest);
+		ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN, loginSuccessResponse.refreshToken())
+			.maxAge(COOKIE_MAX_AGE)
+			.path("/")
+			.secure(true)
+			.sameSite("None")
+			.httpOnly(true)
+			.build();
+
+		return ResponseEntity.ok()
+			.header(HttpHeaders.SET_COOKIE, cookie.toString())
+			.body(SuccessResponse.of(StoreSuccessCode.LOGIN_SUCCESS, loginSuccessResponse));
+	}
+
 	@PostMapping("/logout")
 	public ResponseEntity<SuccessResponse<Void>> logOut(
 		@CurrentMember final Long currentStoreId

--- a/src/main/java/com/napzak/domain/store/api/service/LoginService.java
+++ b/src/main/java/com/napzak/domain/store/api/service/LoginService.java
@@ -12,9 +12,11 @@ import com.napzak.domain.store.core.entity.enums.SocialType;
 import com.napzak.domain.store.core.vo.Store;
 import com.napzak.global.auth.client.dto.StoreSocialInfoResponse;
 import com.napzak.global.auth.client.dto.StoreSocialLoginRequest;
+import com.napzak.global.auth.client.service.KakaoSocialService;
 import com.napzak.global.auth.client.service.SocialService;
 import com.napzak.global.common.exception.NapzakException;
 
+import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -29,6 +31,7 @@ public class LoginService {
 	private final StoreService storeService;
 	private final GoogleSocialService googleSocialService;
 	private final AppleSocialService appleSocialService;
+	private final FileDescriptorMetrics fileDescriptorMetrics;
 
 	@Transactional
 	public LoginSuccessResponse login(
@@ -47,6 +50,16 @@ public class LoginService {
 			log.error("Login failed: ", e);
 			throw e;
 		}
+	}
+
+	public LoginSuccessResponse loginWithAccessToken(
+		String kakaoAccessToken,
+		StoreSocialLoginRequest request) {
+
+		StoreSocialInfoResponse storeInfo = ((KakaoSocialService) kakaoSocialService).loginWithAccessToken(kakaoAccessToken);
+		Long storeId = findOrRegisterStore(storeInfo);
+
+		return returnLoginSuccessResponse(storeId, storeInfo);
 	}
 
 	//소셜 타입에 따라 사용자 정보 조회

--- a/src/main/java/com/napzak/global/auth/client/service/KakaoSocialService.java
+++ b/src/main/java/com/napzak/global/auth/client/service/KakaoSocialService.java
@@ -59,6 +59,12 @@ public class KakaoSocialService implements SocialService {
 		return getLoginDto(loginRequest.socialType(), getUserInfo(accessToken));
 	}
 
+	public StoreSocialInfoResponse loginWithAccessToken(String kakaoAccessToken) {
+
+		KakaoUserResponse kakaoUserResponse = getUserInfo("Bearer " + kakaoAccessToken);
+		return getLoginDto(SocialType.KAKAO, kakaoUserResponse);
+	}
+
 	private String getOAuth2Authentication(
 		final String authorizationCode
 	) {


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #60

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
기존에는

1) 클라이언트에서 auth code 담아 요청
2) 서버에서 auth code로 카카오 access token 요청
3) 얻은 카카오 access token으로 jwt 생성

과정으로 로그인 진행되었는데, 클라이언트 요청에 따라
직접적으로 카카오 access token을 입력받아 로그인 성공 dto 생성하는 api 구현하였습니다. 

안드도 직접 access token 전달 가능하다면 이번에 구현한 방식으로 로그인 로직 통일하는 리팩토링 진행하겠습니다!

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="668" alt="image" src="https://github.com/user-attachments/assets/d50546eb-234f-4149-a1d0-f4cda4da6c23" />
<img width="668" alt="image" src="https://github.com/user-attachments/assets/7c3eb98c-0d60-49e5-b1c9-65b681e1f1e7" />


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
