### PR TITLE
[feat] #80 - 탈퇴 api db변경 플로우 추가 

### DIFF
--- a/src/main/java/com/napzak/domain/interest/core/InterestRemover.java
+++ b/src/main/java/com/napzak/domain/interest/core/InterestRemover.java
@@ -22,4 +22,7 @@ public class InterestRemover {
 	public void deleteAllInterest(Long productId) {
 		interestRepository.deleteByProductId(productId);
 	}
+
+	@Transactional
+	public void deleteAllInterestByStoreId(Long storeId) { interestRepository.deleteByStoreId(storeId);}
 }

--- a/src/main/java/com/napzak/domain/interest/core/InterestRepository.java
+++ b/src/main/java/com/napzak/domain/interest/core/InterestRepository.java
@@ -40,4 +40,11 @@ public interface InterestRepository extends JpaRepository<InterestEntity, Long> 
 				WHERE i.productId = :productId
 			""")
 	void deleteByProductId(@Param("productId") Long productId);
+
+	@Modifying
+	@Query("""
+				DELETE FROM InterestEntity i
+				WHERE i.storeId = :storeId
+			""")
+	void deleteByStoreId(@Param("storeId") Long storeId);
 }

--- a/src/main/java/com/napzak/domain/product/core/ProductRepository.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductRepository.java
@@ -47,10 +47,17 @@ public interface ProductRepository extends JpaRepository<ProductEntity, Long>, P
 		""")
 	void updateTradeStatus(@Param("productId") Long productId, @Param("tradeStatus") TradeStatus tradeStatus);
 
+	@Modifying
+	@Query("""
+		UPDATE ProductEntity p
+		SET p.isVisible = false
+		WHERE p.storeId = :storeId
+		""")
+	void updateIsVisible(@Param("storeId") Long storeId);
+
+	@Query("SELECT p FROM ProductEntity p where p.id = :productId AND p.isVisible = true")
 	Optional<ProductEntity> findById(Long productId);
 
-	boolean existsById(Long productId);
-
-	int countByStoreIdAndTradeType(Long storeId, TradeType tradeType);
+	int countByStoreIdAndTradeTypeAndIsVisibleTrue(Long storeId, TradeType tradeType);
 }
 

--- a/src/main/java/com/napzak/domain/product/core/ProductRepositoryCustomImpl.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductRepositoryCustomImpl.java
@@ -39,6 +39,7 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
 				isUnopenedFilter(isUnopened),
 				tradeTypeFilter(tradeType),
 				isOnSaleFilter(isOnSale),
+				isVisibleFilter(),
 				cursorFilter(cursorProductId, cursorOptionalValue, orderSpecifier)
 			)
 			.orderBy(tradeStatusOrder().asc(), orderSpecifier)
@@ -57,6 +58,7 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
 				isUnopenedFilter(isUnopened),
 				tradeTypeFilter(tradeType),
 				isOnSaleFilter(isOnSale),
+				isVisibleFilter(),
 				cursorFilter(cursorProductId, cursorOptionalValue, orderSpecifier)
 			)
 			.orderBy(tradeStatusOrder().asc(), orderSpecifier)
@@ -75,6 +77,7 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
 				isUnopenedFilter(isUnopened),
 				tradeTypeFilter(tradeType),
 				isOnSaleFilter(isOnSale),
+				isVisibleFilter(),
 				cursorFilter(cursorProductId, cursorOptionalValue, orderSpecifier)
 			)
 			.orderBy(tradeStatusOrder().asc(), orderSpecifier)
@@ -89,7 +92,8 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
 		return queryFactory.selectFrom(productEntity)
 			.where(
 				tradeTypeFilter(tradeType),
-				productEntity.storeId.ne(storeId)
+				productEntity.storeId.ne(storeId),
+				isVisibleFilter()
 			)
 			.orderBy(orderSpecifier)
 			.limit(size)
@@ -104,7 +108,8 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
 				genreFilter(genreIds),
 				isUnopenedFilter(isUnopened),
 				tradeTypeFilter(tradeType),
-				isOnSaleFilter(isOnSale)
+				isOnSaleFilter(isOnSale),
+				isVisibleFilter()
 			)
 			.fetchOne();
 		return count != null ? count : 0L;
@@ -120,7 +125,8 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
 				genreFilter(genreIds),
 				isUnopenedFilter(isUnopened),
 				tradeTypeFilter(tradeType),
-				isOnSaleFilter(isOnSale)
+				isOnSaleFilter(isOnSale),
+				isVisibleFilter()
 			)
 			.fetchOne();
 		return count != null ? count : 0L;
@@ -136,7 +142,8 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
 				genreFilter(genreIds),
 				isUnopenedFilter(isUnopened),
 				tradeTypeFilter(tradeType),
-				isOnSaleFilter(isOnSale)
+				isOnSaleFilter(isOnSale),
+				isVisibleFilter()
 			)
 			.fetchOne();
 		return count != null ? count : 0L;
@@ -154,7 +161,8 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
 				productEntity.genreId.in(genreIds),
 				productEntity.tradeType.in(tradeTypes),
 				productEntity.storeId.ne(excludeStoreId),
-				productEntity.tradeStatus.eq(TradeStatus.BEFORE_TRADE)
+				productEntity.tradeStatus.eq(TradeStatus.BEFORE_TRADE),
+				isVisibleFilter()
 			)
 			.orderBy(productEntity.createdAt.desc())
 			.limit(limit)
@@ -171,7 +179,8 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
 			.where(
 				productEntity.storeId.ne(excludeStoreId),  // 본인 상품 제외
 				productEntity.tradeType.eq(tradeType),     // SELL 또는 BUY 필터링
-				productEntity.tradeStatus.eq(TradeStatus.BEFORE_TRADE) // 거래 가능 상태
+				productEntity.tradeStatus.eq(TradeStatus.BEFORE_TRADE), // 거래 가능 상태
+				isVisibleFilter()
 			)
 			.orderBy(productEntity.createdAt.desc())       // 최신순 정렬
 			.limit(limit)                             // 원하는 개수만큼 조회
@@ -204,6 +213,10 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
 			return productEntity.genreId.in(genreIds);
 		}
 		return null;
+	}
+
+	private BooleanExpression isVisibleFilter() {
+		return productEntity.isVisible.isTrue();
 	}
 
 	private BooleanExpression cursorFilter(Long cursorProductId, Integer cursorOptionalValue,

--- a/src/main/java/com/napzak/domain/product/core/ProductRetriever.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductRetriever.java
@@ -27,11 +27,6 @@ public class ProductRetriever {
 	private static final List<Long> FALLBACK_GENRES = List.of(1L, 7L, 4L, 5L);
 
 	@Transactional(readOnly = true)
-	public boolean existsById(Long productId) {
-		return productRepository.existsById(productId);
-	}
-
-	@Transactional(readOnly = true)
 	public Product findById(Long id) {
 		ProductEntity productEntity = productRepository.findById(id)
 			.orElseThrow(() -> new NapzakException(ProductErrorCode.PRODUCT_NOT_FOUND));
@@ -40,7 +35,7 @@ public class ProductRetriever {
 
 	@Transactional(readOnly = true)
 	public int countProductsByStoreIdAndTradeType(Long storeId, TradeType tradeType) {
-		return productRepository.countByStoreIdAndTradeType(storeId, tradeType);
+		return productRepository.countByStoreIdAndTradeTypeAndIsVisibleTrue(storeId, tradeType);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/napzak/domain/product/core/ProductUpdater.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductUpdater.java
@@ -51,4 +51,9 @@ public class ProductUpdater {
 
 		return Product.fromEntity(productEntity);
 	}
+
+	@Transactional
+	public void updateProductIsVisibleByStoreId(Long storeId) {
+		productRepository.updateIsVisible(storeId);
+	}
 }

--- a/src/main/java/com/napzak/domain/store/api/StoreInterestFacade.java
+++ b/src/main/java/com/napzak/domain/store/api/StoreInterestFacade.java
@@ -1,0 +1,20 @@
+package com.napzak.domain.store.api;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.napzak.domain.interest.core.InterestRemover;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class StoreInterestFacade {
+
+	private final InterestRemover interestRemover;
+
+	@Transactional
+	public void deleteInterestByStoreId(Long storeId) {
+		interestRemover.deleteAllInterestByStoreId(storeId);
+	}
+}

--- a/src/main/java/com/napzak/domain/store/api/StoreProductFacade.java
+++ b/src/main/java/com/napzak/domain/store/api/StoreProductFacade.java
@@ -1,8 +1,10 @@
 package com.napzak.domain.store.api;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.napzak.domain.product.core.ProductRetriever;
+import com.napzak.domain.product.core.ProductUpdater;
 import com.napzak.domain.product.core.entity.enums.TradeType;
 
 import lombok.RequiredArgsConstructor;
@@ -12,8 +14,14 @@ import lombok.RequiredArgsConstructor;
 public class StoreProductFacade {
 
 	private final ProductRetriever productRetriever;
+	private final ProductUpdater productUpdater;
 
 	public int getProductCount(Long storeId, TradeType tradeType) {
 		return productRetriever.countProductsByStoreIdAndTradeType(storeId, tradeType);
+	}
+
+	@Transactional
+	public void updateProductIsVisibleByStoreId(Long storeId) {
+		productUpdater.updateProductIsVisibleByStoreId(storeId);
 	}
 }

--- a/src/main/java/com/napzak/domain/store/api/controller/StoreController.java
+++ b/src/main/java/com/napzak/domain/store/api/controller/StoreController.java
@@ -29,6 +29,7 @@ import com.napzak.domain.genre.api.exception.GenreErrorCode;
 import com.napzak.domain.genre.core.vo.Genre;
 import com.napzak.domain.product.core.entity.enums.TradeType;
 import com.napzak.domain.store.api.StoreGenreFacade;
+import com.napzak.domain.store.api.StoreInterestFacade;
 import com.napzak.domain.store.api.StoreLinkFacade;
 import com.napzak.domain.store.api.StoreProductFacade;
 import com.napzak.domain.store.api.StoreTermsBundleFacade;
@@ -85,6 +86,7 @@ public class StoreController implements StoreApi {
 	private final AuthenticationService authenticationService;
 	private final StoreUseTermsFacade storeUseTermsFacade;
 	private final StoreTermsBundleFacade storeTermsBundleFacade;
+	private final StoreInterestFacade storeInterestFacade;
 
 	@PostMapping("/login")
 	public ResponseEntity<SuccessResponse<LoginSuccessResponse>> login(
@@ -319,6 +321,9 @@ public class StoreController implements StoreApi {
 		@RequestBody @Valid final StoreWithdrawRequest request
 	) {
 		storeService.withdraw(storeId, request.withdrawTitle(), request.withdrawDescription());
+		storeInterestFacade.deleteInterestByStoreId(storeId);
+		storeProductFacade.updateProductIsVisibleByStoreId(storeId);
+
 		StoreWithdrawResponse response = StoreWithdrawResponse.of(
 			storeId,
 			request.withdrawTitle(),

--- a/src/main/java/com/napzak/domain/store/api/service/StoreService.java
+++ b/src/main/java/com/napzak/domain/store/api/service/StoreService.java
@@ -6,9 +6,8 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.napzak.domain.external.core.entity.enums.TermsType;
-import com.napzak.domain.external.core.vo.UseTerms;
 import com.napzak.domain.store.api.exception.StoreErrorCode;
+import com.napzak.domain.store.core.GenrePreferenceRemover;
 import com.napzak.domain.store.core.GenrePreferenceRetriever;
 import com.napzak.domain.store.core.StorePhotoRetriever;
 import com.napzak.domain.store.core.StoreReportSaver;
@@ -41,6 +40,7 @@ public class StoreService {
 	private final WithdrawSaver withdrawSaver;
 	private final StorePhotoRetriever storePhotoRetriever;
 	private final TermsAgreementSaver termsAgreementSaver;
+	private final GenrePreferenceRemover genrePreferenceRemover;
 
 	@Transactional(readOnly = true)
 	public boolean checkStoreExistsBySocialIdAndSocialType(final String socialId, final SocialType socialType) {
@@ -107,6 +107,7 @@ public class StoreService {
 	public void withdraw(Long storeId, String title, String description) {
 		withdrawSaver.save(storeId, title, description, LocalDateTime.now());
 		storeUpdater.updateRole(storeId, Role.WITHDRAWN);
+		genrePreferenceRemover.removeGenrePreference(storeId);
 	}
 
 	@Transactional


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #80

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
상점 탈퇴 시
해당 상점의 interest, genre preference 삭제되도록 하였습니다.
해당 상점의 product의 isVisible 필드를 false로 변경합니다. 

상품 조회 관련 api에서 isVisible이 true인 상품들만 조회되도록 필터를 추가하고 repository 쿼리를 수정하였습니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
- 유저3 탈퇴 전, 유저2의 홈화면 팔아요 조회 응답. 유저3의 product인 6번 product 노출
<img width="702" alt="Pasted Graphic 6" src="https://github.com/user-attachments/assets/0fd01f92-915a-4348-b10e-7333370e28a7" />

- 유저3 탈퇴 후, 유저2의 홈화면 팔아요 조회 응답. 유저3의 product인 6번 product 노출 x
<img width="657" alt="Pasted Graphic 9" src="https://github.com/user-attachments/assets/b36d5706-7cce-48eb-8fc5-5193ee008f4b" />

같은 방식으로 홈 buy, 탐색탭 api 등 확인 완료


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
