### PR TITLE
[feat] #91 - chat presigned-url 발급 api 구현

### DIFF
--- a/src/main/java/com/napzak/global/external/s3/api/controller/FileApi.java
+++ b/src/main/java/com/napzak/global/external/s3/api/controller/FileApi.java
@@ -1,6 +1,7 @@
 package com.napzak.global.external.s3.api.controller;
 
 import com.napzak.global.common.exception.dto.SuccessResponse;
+import com.napzak.global.external.s3.api.dto.ChatPresignedUrlFindAllResponse;
 import com.napzak.global.external.s3.api.dto.ProductPresignedUrlFindAllResponse;
 import com.napzak.global.external.s3.api.dto.StorePresignedUrlFindAllResponse;
 import com.napzak.global.swagger.annotation.DisableSwaggerSecurity;
@@ -40,5 +41,17 @@ public interface FileApi {
 	@GetMapping("/stores")
 	ResponseEntity<SuccessResponse<StorePresignedUrlFindAllResponse>> generatePresignedUrlsForStore(
 		@RequestParam List<String> profileImages);
+
+	@DisableSwaggerSecurity
+	@Operation(summary = "채팅 이미지 Presigned URL 발급", description = "채팅 이미지 메시지 업로드용 Presigned URL을 발급합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "201", description = "Presigned URL 발급 성공",
+			content = @Content(schema = @Schema(implementation = ChatPresignedUrlFindAllResponse.class))),
+		@ApiResponse(responseCode = "400", description = "이미지 리스트가 비어있음")
+	})
+	@GetMapping("/chat")
+	ResponseEntity<SuccessResponse<ChatPresignedUrlFindAllResponse>> generatePresignedUrlsForChat(
+		@RequestParam List<String> chatImages);
+
 
 }

--- a/src/main/java/com/napzak/global/external/s3/api/controller/FileController.java
+++ b/src/main/java/com/napzak/global/external/s3/api/controller/FileController.java
@@ -10,11 +10,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.napzak.global.common.exception.dto.SuccessResponse;
+import com.napzak.global.external.s3.api.dto.ChatPresignedUrlFindAllResponse;
 import com.napzak.global.external.s3.api.dto.ProductPresignedUrlFindAllResponse;
 import com.napzak.global.external.s3.api.dto.StorePresignedUrlFindAllResponse;
 import com.napzak.global.external.s3.api.service.FileService;
 import com.napzak.global.external.s3.exception.FileSuccessCode;
 
+import feign.Response;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -48,4 +50,18 @@ public class FileController implements FileApi {
 		return ResponseEntity.ok(
 			SuccessResponse.of(FileSuccessCode.PRESIGNED_URL_ISSUED, response));
 	}
+
+	@Override
+	@GetMapping("/chat")
+	public ResponseEntity<SuccessResponse<ChatPresignedUrlFindAllResponse>> generatePresignedUrlsForChat(
+		@RequestParam List<String> chatImages) {
+		if (chatImages == null || chatImages.isEmpty()) {
+			throw new IllegalArgumentException("chatImages 리스트는 비어 있을 수 없습니다.");
+		}
+		Map<String, String> urls = fileService.generateAllPresignedUrls(chatImages, "chat");
+		ChatPresignedUrlFindAllResponse response = ChatPresignedUrlFindAllResponse.from(urls);
+		return ResponseEntity.ok(
+			SuccessResponse.of(FileSuccessCode.PRESIGNED_URL_ISSUED, response));
+	}
+
 }

--- a/src/main/java/com/napzak/global/external/s3/api/dto/ChatPresignedUrlFindAllResponse.java
+++ b/src/main/java/com/napzak/global/external/s3/api/dto/ChatPresignedUrlFindAllResponse.java
@@ -1,0 +1,12 @@
+package com.napzak.global.external.s3.api.dto;
+
+import java.util.Map;
+
+public record ChatPresignedUrlFindAllResponse (
+	Map<String, String> chatPresignedUrls
+){
+	public static ChatPresignedUrlFindAllResponse from(
+		Map<String, String> chatPresignedUrls) {
+		return new ChatPresignedUrlFindAllResponse(chatPresignedUrls);
+	}
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #91

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
채팅 메시지의 이미지 업로드를 위한 presigned-url 발급 api 구현하였습니다.  

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="663" alt="image" src="https://github.com/user-attachments/assets/7537e8cb-4282-4d43-9f42-9eca11857934" />


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 채팅 이미지 업로드를 위한 presigned URL을 발급하는 새로운 API 엔드포인트가 추가되었습니다.
- **기타**
    - 채팅 presigned URL 목록을 포함하는 응답 형식이 새롭게 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->