### PR TITLE
[feat] #93 - 사용하지 않는 s3 이미지 일괄 삭제 api 구현

### DIFF
--- a/src/main/java/com/napzak/NapzakApplication.java
+++ b/src/main/java/com/napzak/NapzakApplication.java
@@ -3,9 +3,11 @@ package com.napzak;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableScheduling
 public class NapzakApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/napzak/domain/product/api/ProductStoreFacade.java
+++ b/src/main/java/com/napzak/domain/product/api/ProductStoreFacade.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import com.napzak.domain.store.api.dto.response.StoreStatusDto;
 import com.napzak.domain.store.core.GenrePreferenceRetriever;
 import com.napzak.domain.store.core.StoreRetriever;
+import com.napzak.domain.store.core.entity.enums.Role;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,5 +30,7 @@ public class ProductStoreFacade {
 	public String getStoreNickname(Long storeId) {
 		return storeRetriever.findNicknameByStoreId(storeId);
 	}
+
+	public Role getStoreRole(Long storeId) { return storeRetriever.findStoreByStoreId(storeId).getRole();}
 }
 

--- a/src/main/java/com/napzak/domain/product/api/controller/ProductApi.java
+++ b/src/main/java/com/napzak/domain/product/api/controller/ProductApi.java
@@ -270,7 +270,7 @@ public interface ProductApi {
 		@ApiResponse(responseCode = "200", description = "s3 이미지 삭제 성공"),
 		@ApiResponse(responseCode = "403", description = "접근 권한이 없습니다.")
 	})
-	@GetMapping("/clean")
+	@PostMapping("/clean")
 	ResponseEntity<SuccessResponse<Void>> productPhotoCleanUp(
 		@CurrentMember Long currentStoreId
 	);

--- a/src/main/java/com/napzak/domain/product/api/controller/ProductApi.java
+++ b/src/main/java/com/napzak/domain/product/api/controller/ProductApi.java
@@ -264,4 +264,14 @@ public interface ProductApi {
 		@PathVariable Long productId,
 		@CurrentMember Long storeId
 	);
+
+	@Operation(summary = "사용하지 않는 S3 product 이미지 삭제", description = "사용하지 않는 s3 이미지를 일괄 삭제")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "s3 이미지 삭제 성공"),
+		@ApiResponse(responseCode = "403", description = "접근 권한이 없습니다.")
+	})
+	@GetMapping("/clean")
+	ResponseEntity<SuccessResponse<Void>> productPhotoCleanUp(
+		@CurrentMember Long currentStoreId
+	);
 }

--- a/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
+++ b/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -58,6 +59,7 @@ import com.napzak.domain.product.api.dto.response.RecommendSearchWordDto;
 import com.napzak.domain.product.api.exception.ProductErrorCode;
 import com.napzak.domain.product.api.exception.ProductSuccessCode;
 import com.napzak.domain.product.api.service.ProductPagination;
+import com.napzak.domain.product.api.service.ProductPhotoS3ImageCleaner;
 import com.napzak.domain.product.api.service.ProductService;
 import com.napzak.domain.product.api.service.enums.SortOption;
 import com.napzak.domain.product.core.entity.enums.TradeType;
@@ -83,6 +85,7 @@ public class ProductController implements ProductApi {
 	private final ProductInterestFacade productInterestFacade;
 	private final ProductGenreFacade productGenreFacade;
 	private final ProductStoreFacade productStoreFacade;
+	private final ProductPhotoS3ImageCleaner productPhotoS3ImageCleaner;
 
 	@Override
 	@GetMapping("/sell")
@@ -852,6 +855,21 @@ public class ProductController implements ProductApi {
 			SuccessResponse.of(
 				ProductSuccessCode.INTERESTED_PRODUCT_RETRIEVE_SUCCESS,
 				response
+			));
+	}
+
+	@PostMapping("/clean")
+	public ResponseEntity<SuccessResponse<Void>> productPhotoCleanUp(@CurrentMember Long currentStoreId) {
+		String currentStoreRole = productStoreFacade.getStoreRole(currentStoreId).toString();
+		if(!Objects.equals(currentStoreRole, "ADMIN")) {
+			throw new NapzakException(ProductErrorCode.ACCESS_DENIED);
+		}
+
+		productPhotoS3ImageCleaner.cleanUnusedProductImages();
+
+		return ResponseEntity.ok(
+			SuccessResponse.of(
+				ProductSuccessCode.PRODUCT_PHOTO_DELETE_SUCCESS
 			));
 	}
 

--- a/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
+++ b/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
@@ -67,6 +67,7 @@ import com.napzak.domain.product.core.vo.Product;
 import com.napzak.domain.product.core.vo.ProductPhoto;
 import com.napzak.domain.product.core.vo.ProductWithFirstPhoto;
 import com.napzak.domain.store.api.dto.response.StoreStatusDto;
+import com.napzak.domain.store.core.entity.enums.Role;
 import com.napzak.global.auth.annotation.CurrentMember;
 import com.napzak.global.common.exception.NapzakException;
 import com.napzak.global.common.exception.code.ErrorCode;
@@ -860,8 +861,8 @@ public class ProductController implements ProductApi {
 
 	@PostMapping("/clean")
 	public ResponseEntity<SuccessResponse<Void>> productPhotoCleanUp(@CurrentMember Long currentStoreId) {
-		String currentStoreRole = productStoreFacade.getStoreRole(currentStoreId).toString();
-		if(!Objects.equals(currentStoreRole, "ADMIN")) {
+		Role currentStoreRole = productStoreFacade.getStoreRole(currentStoreId);
+		if(currentStoreRole != Role.ADMIN) {
 			throw new NapzakException(ProductErrorCode.ACCESS_DENIED);
 		}
 

--- a/src/main/java/com/napzak/domain/product/api/exception/ProductSuccessCode.java
+++ b/src/main/java/com/napzak/domain/product/api/exception/ProductSuccessCode.java
@@ -25,6 +25,7 @@ public enum ProductSuccessCode implements BaseSuccessCode {
 	PRODUCT_MODIFY_SUCCESS(HttpStatus.OK, "상품 수정이 성공하였습니다"),
 	RECOMMEND_SEARCH_WORD_AND_GENRE_GET_SUCCESS(HttpStatus.OK, "추천 검색어 및 추천 장르가 조회되었습니다."),
 	INTERESTED_PRODUCT_RETRIEVE_SUCCESS(HttpStatus.OK, "찜한 상품 목록이 조회되었습니다."),
+	PRODUCT_PHOTO_DELETE_SUCCESS(HttpStatus.OK, "product S3 이미지가 삭제되었습니다."),
 
 	/*
 	201 Created

--- a/src/main/java/com/napzak/domain/product/api/service/ProductPhotoS3ImageCleaner.java
+++ b/src/main/java/com/napzak/domain/product/api/service/ProductPhotoS3ImageCleaner.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -22,6 +23,9 @@ public class ProductPhotoS3ImageCleaner {
 	private final ProductPhotoRepository productPhotoRepository;
 	private final ProductReportRepository productReportRepository;
 	private final S3ImageCleaner s3ImageCleaner;
+
+	@Value("${cloud.s3.base-url}")
+	private String baseUrl;
 
 	//@Scheduled(cron = "0 0 3 * * ?", zone = "Asia/Seoul")
 	public void cleanUnusedProductImagesScheduled() {
@@ -63,6 +67,5 @@ public class ProductPhotoS3ImageCleaner {
 
 	//photoUrl에서 prefix를 제거하는 메서드
 	private String toKey(String url) {
-		return url.replace("https://napzak-dev-bucket.s3.ap-northeast-2.amazonaws.com/", "");
-	}
+		return url.replace(baseUrl + "/", "");	}
 }

--- a/src/main/java/com/napzak/domain/product/api/service/ProductPhotoS3ImageCleaner.java
+++ b/src/main/java/com/napzak/domain/product/api/service/ProductPhotoS3ImageCleaner.java
@@ -27,7 +27,7 @@ public class ProductPhotoS3ImageCleaner {
 	@Value("${cloud.s3.base-url}")
 	private String baseUrl;
 
-	//@Scheduled(cron = "0 0 3 * * ?", zone = "Asia/Seoul")
+	@Scheduled(cron = "0 00 01 ? * WED", zone = "Asia/Seoul")
 	public void cleanUnusedProductImagesScheduled() {
 		cleanUnusedProductImages();
 	}

--- a/src/main/java/com/napzak/domain/product/api/service/ProductPhotoS3ImageCleaner.java
+++ b/src/main/java/com/napzak/domain/product/api/service/ProductPhotoS3ImageCleaner.java
@@ -1,0 +1,68 @@
+package com.napzak.domain.product.api.service;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.napzak.domain.product.core.ProductPhotoRepository;
+import com.napzak.domain.product.core.ProductReportRepository;
+import com.napzak.global.external.s3.api.service.S3ImageCleaner;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ProductPhotoS3ImageCleaner {
+
+	private final ProductPhotoRepository productPhotoRepository;
+	private final ProductReportRepository productReportRepository;
+	private final S3ImageCleaner s3ImageCleaner;
+
+	@Scheduled(cron = "0 0 3 * * ?", zone = "Asia/Seoul")
+	public void cleanUnusedProductImagesScheduled() {
+		cleanUnusedProductImages();
+	}
+
+	public void cleanUnusedProductImages() {
+
+		Set<String> validKeys = collectValidProductImageKeys();
+		List<String> allS3Keys = s3ImageCleaner.listS3Keys("product/");
+
+		List<String> unusedKeys = allS3Keys.stream()
+			.filter(key -> !validKeys.contains(key))
+			.toList();
+
+		System.out.println("----------validKeys = " + validKeys);
+		System.out.println("----------allS3Keys: " + allS3Keys);
+		System.out.println("----------Unused keys: " + unusedKeys);
+
+		s3ImageCleaner.deleteS3Keys(unusedKeys);
+	}
+
+
+	//현재 db에 등록되어 있는 product Images를 추출하는 메서드 (삭제하면 안되는 이미지)
+	private Set<String> collectValidProductImageKeys() {
+		Set<String> keys = new HashSet<>();
+
+		keys.addAll(productPhotoRepository.findAllPhotoUrls().stream()
+			.map(this::toKey)
+			.collect(Collectors.toSet()));
+
+		keys.addAll(productReportRepository.findAllReportedProductImages().stream()
+			.flatMap(images -> Arrays.stream(images.split("\n")))
+			.map(this::toKey)
+			.collect(Collectors.toSet()));
+
+		return keys;
+	}
+
+	//photoUrl에서 prefix를 제거하는 메서드
+	private String toKey(String url) {
+		return url.replace("https://napzak-dev-bucket.s3.ap-northeast-2.amazonaws.com/", "");
+	}
+}

--- a/src/main/java/com/napzak/domain/product/api/service/ProductPhotoS3ImageCleaner.java
+++ b/src/main/java/com/napzak/domain/product/api/service/ProductPhotoS3ImageCleaner.java
@@ -27,7 +27,7 @@ public class ProductPhotoS3ImageCleaner {
 	@Value("${cloud.s3.base-url}")
 	private String baseUrl;
 
-	@Scheduled(cron = "0 00 01 ? * WED", zone = "Asia/Seoul")
+	@Scheduled(cron = "0 00 20 ? * TUE", zone = "Asia/Seoul")
 	public void cleanUnusedProductImagesScheduled() {
 		cleanUnusedProductImages();
 	}

--- a/src/main/java/com/napzak/domain/product/api/service/ProductPhotoS3ImageCleaner.java
+++ b/src/main/java/com/napzak/domain/product/api/service/ProductPhotoS3ImageCleaner.java
@@ -23,7 +23,7 @@ public class ProductPhotoS3ImageCleaner {
 	private final ProductReportRepository productReportRepository;
 	private final S3ImageCleaner s3ImageCleaner;
 
-	@Scheduled(cron = "0 0 3 * * ?", zone = "Asia/Seoul")
+	//@Scheduled(cron = "0 0 3 * * ?", zone = "Asia/Seoul")
 	public void cleanUnusedProductImagesScheduled() {
 		cleanUnusedProductImages();
 	}

--- a/src/main/java/com/napzak/domain/product/core/ProductPhotoRepository.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductPhotoRepository.java
@@ -35,4 +35,7 @@ public interface ProductPhotoRepository extends JpaRepository<ProductPhotoEntity
 	@Query("DELETE FROM ProductPhotoEntity p WHERE p.productId = :productId")
 	void deleteAllByProductId(@Param("productId") Long productId);
 
+	@Query("SELECT p.photoUrl FROM ProductPhotoEntity p")
+	List<String> findAllPhotoUrls();
+
 }

--- a/src/main/java/com/napzak/domain/product/core/ProductReportRepository.java
+++ b/src/main/java/com/napzak/domain/product/core/ProductReportRepository.java
@@ -1,8 +1,15 @@
 package com.napzak.domain.product.core;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.napzak.domain.product.core.entity.ProductReportEntity;
 
 public interface ProductReportRepository extends JpaRepository<ProductReportEntity, Long> {
+
+	@Query("SELECT p.reportedProductImages FROM ProductReportEntity p")
+	List<String> findAllReportedProductImages();
+
 }

--- a/src/main/java/com/napzak/global/external/s3/api/service/S3ImageCleaner.java
+++ b/src/main/java/com/napzak/global/external/s3/api/service/S3ImageCleaner.java
@@ -1,0 +1,50 @@
+package com.napzak.global.external.s3.api.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class S3ImageCleaner {
+
+	@Value("${cloud.s3.bucket}")
+	private String bucket;
+
+	private final AmazonS3 amazonS3;
+
+	//주어진 prefix에 해당하는 S3 key 전체 목록을 가져오는 메서드
+	public List<String> listS3Keys(String prefix) {
+		List<String> allS3Keys = new ArrayList<>();
+		ListObjectsV2Request request = new ListObjectsV2Request().withBucketName(bucket).withPrefix(prefix);
+		ListObjectsV2Result result;
+
+		do {
+			result = amazonS3.listObjectsV2(request);
+			result.getObjectSummaries().forEach(s -> allS3Keys.add(s.getKey()));
+			request.setContinuationToken(result.getNextContinuationToken());
+		} while (result.isTruncated());
+
+		return allS3Keys;
+	}
+
+	//S3 key들 중 unusedKeys만 일괄삭제하는 메서드
+	public void deleteS3Keys(List<String> unusedKeys) {
+		for (int i = 0; i < unusedKeys.size(); i += 1000) {
+			List<DeleteObjectsRequest.KeyVersion> batch = unusedKeys.subList(i, Math.min(i + 1000, unusedKeys.size()))
+				.stream().map(DeleteObjectsRequest.KeyVersion::new).toList();
+
+			System.out.println("batch = " + batch);
+			amazonS3.deleteObjects(new DeleteObjectsRequest(bucket).withKeys(batch));
+		}
+	}
+}

--- a/src/main/java/com/napzak/global/external/s3/api/service/S3ImageCleaner.java
+++ b/src/main/java/com/napzak/global/external/s3/api/service/S3ImageCleaner.java
@@ -3,19 +3,27 @@ package com.napzak.global.external.s3.api.service;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
 
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.napzak.global.common.exception.NapzakException;
+import com.napzak.global.external.s3.exception.FileErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class S3ImageCleaner {
+
+	private static final Logger logger = LoggerFactory.getLogger(S3ImageCleaner.class);
 
 	@Value("${cloud.s3.bucket}")
 	private String bucket;
@@ -24,27 +32,40 @@ public class S3ImageCleaner {
 
 	//주어진 prefix에 해당하는 S3 key 전체 목록을 가져오는 메서드
 	public List<String> listS3Keys(String prefix) {
-		List<String> allS3Keys = new ArrayList<>();
-		ListObjectsV2Request request = new ListObjectsV2Request().withBucketName(bucket).withPrefix(prefix);
-		ListObjectsV2Result result;
+		try{
+			List<String> allS3Keys = new ArrayList<>();
+			ListObjectsV2Request request = new ListObjectsV2Request().withBucketName(bucket).withPrefix(prefix);
+			ListObjectsV2Result result;
 
-		do {
-			result = amazonS3.listObjectsV2(request);
-			result.getObjectSummaries().forEach(s -> allS3Keys.add(s.getKey()));
-			request.setContinuationToken(result.getNextContinuationToken());
-		} while (result.isTruncated());
+			do {
+				result = amazonS3.listObjectsV2(request);
+				result.getObjectSummaries().forEach(s -> allS3Keys.add(s.getKey()));
+				request.setContinuationToken(result.getNextContinuationToken());
+			} while (result.isTruncated());
 
-		return allS3Keys;
+			return allS3Keys;
+		}
+		catch (AmazonS3Exception e) { throw new NapzakException(FileErrorCode.S3_ACCESS_DENIED); }
+		catch (SdkClientException e) { throw new NapzakException(FileErrorCode.S3_SERVICE_UNAVAILABLE); }
+		catch (Exception e) { throw new NapzakException(FileErrorCode.INTERNAL_SERVER_ERROR); }
 	}
 
 	//S3 key들 중 unusedKeys만 일괄삭제하는 메서드
 	public void deleteS3Keys(List<String> unusedKeys) {
-		for (int i = 0; i < unusedKeys.size(); i += 1000) {
-			List<DeleteObjectsRequest.KeyVersion> batch = unusedKeys.subList(i, Math.min(i + 1000, unusedKeys.size()))
-				.stream().map(DeleteObjectsRequest.KeyVersion::new).toList();
+		if (unusedKeys.isEmpty()) {
+			return;
+		}
+		try{
+			for (int i = 0; i < unusedKeys.size(); i += 1000) {
+				List<DeleteObjectsRequest.KeyVersion> batch = unusedKeys.subList(i, Math.min(i + 1000, unusedKeys.size()))
+					.stream().map(DeleteObjectsRequest.KeyVersion::new).toList();
 
-			System.out.println("batch = " + batch);
-			amazonS3.deleteObjects(new DeleteObjectsRequest(bucket).withKeys(batch));
+				System.out.println("batch = " + batch);
+				amazonS3.deleteObjects(new DeleteObjectsRequest(bucket).withKeys(batch));
+			}
+		} catch(Exception e) {
+			logger.error("S3 키 삭제 실패", e);
+			throw new NapzakException(FileErrorCode.INTERNAL_SERVER_ERROR);
 		}
 	}
 }

--- a/src/main/java/com/napzak/global/external/s3/exception/FileErrorCode.java
+++ b/src/main/java/com/napzak/global/external/s3/exception/FileErrorCode.java
@@ -1,0 +1,32 @@
+package com.napzak.global.external.s3.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.napzak.global.common.exception.base.BaseErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum FileErrorCode implements BaseErrorCode {
+	/*
+	403 FORBIDDEN
+	 */
+	S3_ACCESS_DENIED(HttpStatus.FORBIDDEN, "S3 접근이 거부되었습니다."),
+
+	/*
+	5000
+	 */
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 오류가 발생했습니다."),
+
+	/*
+	503
+	 */
+	S3_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "S3 서비스에 접근할 수 없습니다.")
+	;
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #93

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
productPhoto 테이블과 productReport 테이블을 조회하여 각각 photoUrl, reportedProductImages 를 추출하고, 앞 prefix를 제거해 key를 추출합니다. 
/product, /store과 같은 폴더명을 파라미터로 받아 해당 폴더에 있는 s3 이미지들의 key들을 가져옵니다. 
db의 key들, s3의 key들을 비교하여 사용하지 않는 key들을 추출하고 1000개씩 일괄 삭제합니다. 

스케쥴 어노테이션으로 서버시간기준 새벽 3시마다 삭제되게 했습니다. (근데 일단은 이것 주석처리 해놨어요)
수동으로도 삭제할 수 있게 api로도 연결해놓았습니다. 

prod bucket 연결해서 테스트해봤어욥


## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
## 테스트1
reported images 없음
productPhoto에서 for-test-image 사용중
삭제되어야 할 이미지 : image-1, image-2, image-4, image-5

### 삭제 전 prod 버킷 product 폴더 내부
<img width="991" alt="image" src="https://github.com/user-attachments/assets/8877883d-cd12-4ca7-ac64-2be0c04971a4" />

### 삭제 api 요청 성공
<img width="969" alt="image" src="https://github.com/user-attachments/assets/66af1b71-6179-480f-8da1-8fa82ebe28ce" />

### 삭제 후 prod 버킷 product 폴더 내부
<img width="1007" alt="image" src="https://github.com/user-attachments/assets/13eb7375-3321-42c4-b8e2-b21bff0d19c6" />

### 관련 로그
<img width="1072" alt="image" src="https://github.com/user-attachments/assets/1615d10a-ce96-425a-87a5-e3dce3dd0413" />
1. validKeys : 현재 productPhoto 테이블 및 productReport 테이블에서 사용중인 image url
2. allS3Keys : 현재 버킷 Produt 폴더에 있는 S3 이미지들 keys
3. Unused keys : 사용되고 있지 않은 S3 이미지들 keys ( 2.에서 1. 을 제외한 것)

---

## 테스트2
reported images로 image-1, image-2, image-3 사용중
productPhoto에서 for-test-image 사용중
삭제되어야 할 이미지 : image-4, image-5

### 삭제 전 prod 버킷 product 폴더 내부
<img width="953" alt="image" src="https://github.com/user-attachments/assets/1c30ca1a-bc57-437d-bc66-97aaae8a15f4" />

### 삭제 후 prod 버킷 product 폴더 내부
<img width="938" alt="image" src="https://github.com/user-attachments/assets/0d09df40-699e-47e9-9165-6c851911e686" />



## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

코드리뷰 반영할 것이 있으면 반영 후 store 이미지 삭제도 같은 방식으로 작업하겠습니다!
이미지 key들 삭제된 로그 파일에 저장해서 디스코드로 하루마다 파일이 보내지도록 하는 게 좋을까요?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용하지 않는 상품 이미지를 S3에서 일괄 삭제하는 관리용 클린업 API가 추가되었습니다. (관리자 권한 필요)
  - 상품 이미지 정리 작업의 성공 메시지가 추가되었습니다.
  - 스토어 역할 조회 기능이 추가되어 관리자 권한 확인이 강화되었습니다.
  - S3 이미지 키 목록 조회 및 삭제 기능이 새롭게 도입되어 안정적인 이미지 관리가 가능합니다.
  - S3 관련 오류에 대한 세부 에러 코드가 추가되어 문제 대응이 용이해졌습니다.
  - 주기적인 상품 이미지 미사용 데이터 클린업 작업이 스케줄러로 자동 실행됩니다.

- **기타**
  - 상품 이미지 및 신고 이미지의 DB 조회 기능이 추가되어, S3와의 비교 후 미사용 이미지를 안전하게 삭제할 수 있습니다.

- **버그 수정**
  - 없음
<!-- end of auto-generated comment: release notes by coderabbit.ai -->