### PR TITLE
[feat] #95 - 사용하지 않는 store S3 이미지 삭제

### DIFF
--- a/src/main/java/com/napzak/domain/store/api/controller/StoreController.java
+++ b/src/main/java/com/napzak/domain/store/api/controller/StoreController.java
@@ -27,6 +27,8 @@ import com.napzak.domain.genre.api.dto.response.GenreNameDto;
 import com.napzak.domain.genre.api.dto.response.GenreNameListResponse;
 import com.napzak.domain.genre.api.exception.GenreErrorCode;
 import com.napzak.domain.genre.core.vo.Genre;
+import com.napzak.domain.product.api.exception.ProductErrorCode;
+import com.napzak.domain.product.api.exception.ProductSuccessCode;
 import com.napzak.domain.product.core.entity.enums.TradeType;
 import com.napzak.domain.store.api.StoreGenreFacade;
 import com.napzak.domain.store.api.StoreInterestFacade;
@@ -55,8 +57,11 @@ import com.napzak.domain.store.api.exception.StoreErrorCode;
 import com.napzak.domain.store.api.exception.StoreSuccessCode;
 import com.napzak.domain.store.api.service.AuthenticationService;
 import com.napzak.domain.store.api.service.LoginService;
+import com.napzak.domain.store.api.service.StorePhotoS3ImageCleaner;
 import com.napzak.domain.store.api.service.StoreRegistrationService;
 import com.napzak.domain.store.api.service.StoreService;
+import com.napzak.domain.store.core.StoreRetriever;
+import com.napzak.domain.store.core.entity.enums.Role;
 import com.napzak.domain.store.core.vo.GenrePreference;
 import com.napzak.domain.store.core.vo.Store;
 import com.napzak.global.auth.annotation.CurrentMember;
@@ -87,6 +92,8 @@ public class StoreController implements StoreApi {
 	private final StoreUseTermsFacade storeUseTermsFacade;
 	private final StoreTermsBundleFacade storeTermsBundleFacade;
 	private final StoreInterestFacade storeInterestFacade;
+	private final StoreRetriever storeRetriever;
+	private final StorePhotoS3ImageCleaner storePhotoS3ImageCleaner;
 
 	@PostMapping("/login")
 	public ResponseEntity<SuccessResponse<LoginSuccessResponse>> login(
@@ -347,6 +354,21 @@ public class StoreController implements StoreApi {
 	) {
 		storeService.changeStoreRole(storeId, roleDto.role());
 		return ResponseEntity.ok(SuccessResponse.of(StoreSuccessCode.CHANGE_STORE_ROLE_SUCCESS));
+	}
+
+	@PostMapping("/clean")
+	public ResponseEntity<SuccessResponse<Void>> storePhotoCleanUp(@CurrentMember Long currentStoreId) {
+		Role currentStoreRole = storeRetriever.findStoreByStoreId(currentStoreId).getRole();
+		if(currentStoreRole != Role.ADMIN) {
+			throw new NapzakException(StoreErrorCode.ACCESS_DENIED);
+		}
+
+		storePhotoS3ImageCleaner.cleanUnusedStoreImages();
+
+		return ResponseEntity.ok(
+			SuccessResponse.of(
+				StoreSuccessCode.STORE_PHOTO_DELETE_SUCCESS
+			));
 	}
 
 

--- a/src/main/java/com/napzak/domain/store/api/exception/StoreErrorCode.java
+++ b/src/main/java/com/napzak/domain/store/api/exception/StoreErrorCode.java
@@ -19,6 +19,11 @@ public enum StoreErrorCode implements BaseErrorCode {
 	SOCIAL_TYPE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인 타입입니다."),
 
 	/*
+	403 Forbidden
+	 */
+	ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+	/*
+
 	404 Not Found
 	 */
 	STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 사용자가 없습니다."),

--- a/src/main/java/com/napzak/domain/store/api/exception/StoreSuccessCode.java
+++ b/src/main/java/com/napzak/domain/store/api/exception/StoreSuccessCode.java
@@ -26,6 +26,7 @@ public enum StoreSuccessCode implements BaseSuccessCode {
 	GET_PROFILE_SUCCESS(HttpStatus.OK, "상점 프로필이 성공적으로 조회되었습니다."),
 	PROFILE_UPDATE_SUCCESS(HttpStatus.OK, "상점 프로필이 성공적으로 수정되었습니다."),
 	CHANGE_STORE_ROLE_SUCCESS(HttpStatus.OK, "유저 role 변경이 완료되었습니다."),
+	STORE_PHOTO_DELETE_SUCCESS(HttpStatus.OK, "사용하지 않는 S3 유저 이미지가 삭제되었습니다."),
 	/*
 	201 Created
 	 */

--- a/src/main/java/com/napzak/domain/store/api/service/StorePhotoS3ImageCleaner.java
+++ b/src/main/java/com/napzak/domain/store/api/service/StorePhotoS3ImageCleaner.java
@@ -29,7 +29,7 @@ public class StorePhotoS3ImageCleaner {
 	@Value("${cloud.s3.base-url}")
 	private String baseUrl;
 
-	@Scheduled(cron = "0 15 00 ? * WED", zone = "Asia/Seoul")
+	@Scheduled(cron = "0 20 00 ? * WED", zone = "Asia/Seoul")
 	public void cleanUnusedStoreImagesScheduled() {
 		cleanUnusedStoreImages();
 	}

--- a/src/main/java/com/napzak/domain/store/api/service/StorePhotoS3ImageCleaner.java
+++ b/src/main/java/com/napzak/domain/store/api/service/StorePhotoS3ImageCleaner.java
@@ -1,0 +1,77 @@
+package com.napzak.domain.store.api.service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.napzak.domain.store.core.StorePhotoRepository;
+import com.napzak.domain.store.core.StoreReportRepository;
+import com.napzak.domain.store.core.StoreRepository;
+import com.napzak.global.external.s3.api.service.S3ImageCleaner;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class StorePhotoS3ImageCleaner {
+
+	private final S3ImageCleaner s3ImageCleaner;
+	private final StoreRepository storeRepository;
+	private final StorePhotoRepository storePhotoRepository;
+	private final StoreReportRepository storeReportRepository;
+
+	@Value("${cloud.s3.base-url}")
+	private String baseUrl;
+
+	//@Scheduled(cron = "")
+	public void cleanUnusedStoreImagesScheduled() {
+		cleanUnusedStoreImages();
+	}
+
+	public void cleanUnusedStoreImages() {
+
+		Set<String> validKeys = collectValidStoreImageKeys();
+		List<String> allS3Keys = s3ImageCleaner.listS3Keys("store/");
+
+		List<String> unusedKeys = allS3Keys.stream()
+			.filter(key -> !validKeys.contains(key))
+			.filter(key -> !key.equals("store/"))
+			.toList();
+
+		System.out.println("----------validKeys = " + validKeys);
+		System.out.println("----------allS3Keys: " + allS3Keys);
+		System.out.println("----------Unused keys: " + unusedKeys);
+
+		s3ImageCleaner.deleteS3Keys(unusedKeys);
+	}
+
+	private Set<String> collectValidStoreImageKeys() {
+		Set<String> keys = new HashSet<>();
+
+		keyAdder(keys, storeRepository.findAllCover());
+		keyAdder(keys, storeRepository.findAllPhoto());
+		keyAdder(keys, storePhotoRepository.findAllPhotoUrl());
+
+		keyAdder(keys, storeReportRepository.findAllReportedStoreCover());
+		keyAdder(keys, storeReportRepository.findAllReportedStoreProfile());
+
+		return keys;
+	}
+
+	private void keyAdder(Set<String> keys, List<String> needToKeys) {
+		keys.addAll(needToKeys.stream()
+			.map(this::toKey)
+			.filter(Objects::nonNull)
+			.collect(Collectors.toSet()));
+	}
+
+	private String toKey(String url) {
+		if (url == null) return null;
+		return url.replace(baseUrl + "/", "");
+	}
+}

--- a/src/main/java/com/napzak/domain/store/api/service/StorePhotoS3ImageCleaner.java
+++ b/src/main/java/com/napzak/domain/store/api/service/StorePhotoS3ImageCleaner.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.napzak.domain.store.core.StorePhotoRepository;
@@ -28,7 +29,7 @@ public class StorePhotoS3ImageCleaner {
 	@Value("${cloud.s3.base-url}")
 	private String baseUrl;
 
-	//@Scheduled(cron = "")
+	@Scheduled(cron = "0 15 00 ? * WED", zone = "Asia/Seoul")
 	public void cleanUnusedStoreImagesScheduled() {
 		cleanUnusedStoreImages();
 	}

--- a/src/main/java/com/napzak/domain/store/core/StorePhotoRepository.java
+++ b/src/main/java/com/napzak/domain/store/core/StorePhotoRepository.java
@@ -1,8 +1,10 @@
 package com.napzak.domain.store.core;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.napzak.domain.store.core.entity.StorePhotoEntity;
 import com.napzak.domain.store.core.entity.enums.PhotoType;
@@ -10,4 +12,6 @@ import com.napzak.domain.store.core.entity.enums.PhotoType;
 public interface StorePhotoRepository extends JpaRepository<StorePhotoEntity, Long> {
 	Optional<StorePhotoEntity> findByPhotoType(PhotoType photoType);
 
+	@Query("SELECT s.photoUrl FROM StorePhotoEntity s")
+	List<String> findAllPhotoUrl();
 }

--- a/src/main/java/com/napzak/domain/store/core/StoreReportRepository.java
+++ b/src/main/java/com/napzak/domain/store/core/StoreReportRepository.java
@@ -12,6 +12,6 @@ public interface StoreReportRepository extends JpaRepository<StoreReportEntity, 
 	@Query("SELECT s.reportedStoreCover FROM StoreReportEntity s")
 	List<String> findAllReportedStoreCover();
 
-	@Query("SELECT s.reportedStoreProfile FROm StoreReportEntity s")
+	@Query("SELECT s.reportedStoreProfile FROM StoreReportEntity s")
 	List<String> findAllReportedStoreProfile();
 }

--- a/src/main/java/com/napzak/domain/store/core/StoreReportRepository.java
+++ b/src/main/java/com/napzak/domain/store/core/StoreReportRepository.java
@@ -1,8 +1,17 @@
 package com.napzak.domain.store.core;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.napzak.domain.store.core.entity.StoreReportEntity;
 
 public interface StoreReportRepository extends JpaRepository<StoreReportEntity, Long> {
+
+	@Query("SELECT s.reportedStoreCover FROM StoreReportEntity s")
+	List<String> findAllReportedStoreCover();
+
+	@Query("SELECT s.reportedStoreProfile FROm StoreReportEntity s")
+	List<String> findAllReportedStoreProfile();
 }

--- a/src/main/java/com/napzak/domain/store/core/StoreRepository.java
+++ b/src/main/java/com/napzak/domain/store/core/StoreRepository.java
@@ -1,5 +1,6 @@
 package com.napzak.domain.store.core;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -37,4 +38,9 @@ public interface StoreRepository extends JpaRepository<StoreEntity, Long> {
 
 	boolean existsByNickname(String nickname);
 
+	@Query("SELECT s.cover FROM StoreEntity s")
+	List<String> findAllCover();
+
+	@Query("SELECT s.photo FROM StoreEntity s")
+	List<String> findAllPhoto();
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #95

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
product와 같은 방식으로 작업하였습니다. 
store table의 cover, profile
storePhoto table의 photoUrl
storeReport table의 reportedStoreCover, reportedStoreProfile 을
key로 추출하여 S3 등록된 이미지와 비교해 사용중이지 않은 이미지는 삭제합니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

db 상태 : image-1, 2, 4, image-for-test 사용중. 
버킷 상태 : image-1, 2, 3, 4, 5, image-for-test 사용중
삭제되어야 할 이미지: image-3, image-5

### 실행 후 postman
<img width="667" alt="image" src="https://github.com/user-attachments/assets/bb4464bb-f69e-4c4c-8b63-a80665952d6f" />

### key 로그
<img width="1153" alt="image" src="https://github.com/user-attachments/assets/c13008a9-56e9-498f-8134-f6addda94944" />


 ### 실행 후 버킷 상태
<img width="1203" alt="image" src="https://github.com/user-attachments/assets/306d5e4c-2005-423a-9fef-d1cb0327b282" />

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 사용하지 않는 매장 사진을 S3에서 정리하는 새로운 관리 기능이 추가되었습니다. 관리자는 전용 엔드포인트를 통해 즉시 정리를 실행할 수 있습니다.
    - 매주 수요일 00:20(서울 기준)에 자동으로 이미지 정리가 실행됩니다.
- **버그 수정**
    - 접근 권한이 없는 사용자가 정리 기능을 사용할 경우 접근 거부 메시지가 제공됩니다.
- **알림 및 메시지**
    - 이미지 정리 성공 시 관련 안내 메시지가 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->