### PR TITLE
[feat] #79 - 권한 인가 AOP + JWT role 검증 개선

### DIFF
--- a/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
+++ b/src/main/java/com/napzak/domain/product/api/controller/ProductController.java
@@ -58,6 +58,8 @@ import com.napzak.domain.product.core.vo.Product;
 import com.napzak.domain.product.core.vo.ProductPhoto;
 import com.napzak.domain.product.core.vo.ProductWithFirstPhoto;
 import com.napzak.domain.store.api.dto.response.StoreStatusDto;
+import com.napzak.domain.store.core.entity.enums.Role;
+import com.napzak.global.auth.annotation.AuthorizedRole;
 import com.napzak.global.auth.annotation.CurrentMember;
 import com.napzak.global.common.exception.NapzakException;
 import com.napzak.global.common.exception.code.ErrorCode;
@@ -78,6 +80,7 @@ public class ProductController implements ProductApi {
 	private final ProductReviewFacade productReviewFacade;
 	private final ProductStoreFacade productStoreFacade;
 
+	@AuthorizedRole({Role.ADMIN, Role.STORE})
 	@Override
 	@GetMapping("/sell")
 	public ResponseEntity<SuccessResponse<ProductSellListResponse>> getSellProducts(

--- a/src/main/java/com/napzak/domain/store/api/service/AuthenticationService.java
+++ b/src/main/java/com/napzak/domain/store/api/service/AuthenticationService.java
@@ -122,7 +122,7 @@ public class AuthenticationService {
 			log.info("Creating AdminAuthentication for storeId: {}", storeId);
 			return new AdminAuthentication(storeId, null, authorities);
 		} else {
-			log.info("Creating StoreAuthentication for storeId: {}", storeId);
+			log.info("Creating MemberAuthentication for storeId: {}", storeId);
 			return new MemberAuthentication(storeId, null, authorities);
 		}
 	}

--- a/src/main/java/com/napzak/domain/store/api/service/StoreRoleProvider.java
+++ b/src/main/java/com/napzak/domain/store/api/service/StoreRoleProvider.java
@@ -1,0 +1,29 @@
+package com.napzak.domain.store.api.service;
+
+import com.napzak.domain.store.api.exception.StoreErrorCode;
+import com.napzak.domain.store.core.StoreRetriever;
+import com.napzak.domain.store.core.entity.enums.Role;
+import com.napzak.global.auth.role.RoleProvider;
+import com.napzak.global.common.exception.NapzakException;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StoreRoleProvider implements RoleProvider {
+
+	private final StoreRetriever storeRetriever;
+
+	@Override
+	public boolean supports(String authenticationType) {
+		return authenticationType.equals("MemberAuthentication")
+			|| authenticationType.equals("AdminAuthentication");
+	}
+
+	@Override
+	public Role provideRole(Long id) {
+		return storeRetriever.findRoleByStoreId(id)
+			.orElseThrow(() -> new NapzakException(StoreErrorCode.STORE_NOT_FOUND));
+	}
+}

--- a/src/main/java/com/napzak/domain/store/core/StoreRepository.java
+++ b/src/main/java/com/napzak/domain/store/core/StoreRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import com.napzak.domain.store.api.dto.response.StoreStatusDto;
 import com.napzak.domain.store.core.entity.StoreEntity;
+import com.napzak.domain.store.core.entity.enums.Role;
 import com.napzak.domain.store.core.entity.enums.SocialType;
 
 import feign.Param;
@@ -37,4 +38,6 @@ public interface StoreRepository extends JpaRepository<StoreEntity, Long> {
 
 	boolean existsByNickname(String nickname);
 
+	@Query("SELECT u.role FROM StoreEntity u WHERE u.id = :storeId")
+	Optional<Role> findRoleByStoreId(@Param("storeId") Long storeId);
 }

--- a/src/main/java/com/napzak/domain/store/core/StoreRetriever.java
+++ b/src/main/java/com/napzak/domain/store/core/StoreRetriever.java
@@ -1,11 +1,14 @@
 package com.napzak.domain.store.core;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.napzak.domain.store.api.dto.response.StoreStatusDto;
 import com.napzak.domain.store.api.exception.StoreErrorCode;
 import com.napzak.domain.store.core.entity.StoreEntity;
+import com.napzak.domain.store.core.entity.enums.Role;
 import com.napzak.domain.store.core.entity.enums.SocialType;
 import com.napzak.domain.store.core.vo.Store;
 import com.napzak.global.common.exception.NapzakException;
@@ -64,4 +67,6 @@ public class StoreRetriever {
 	public boolean existsByNickname(String nickname) {
 		return storeRepository.existsByNickname(nickname);
 	}
+
+	public Optional<Role> findRoleByStoreId(Long storeId) { return storeRepository.findRoleByStoreId(storeId); }
 }

--- a/src/main/java/com/napzak/domain/store/core/vo/StoreSession.java
+++ b/src/main/java/com/napzak/domain/store/core/vo/StoreSession.java
@@ -1,0 +1,20 @@
+package com.napzak.domain.store.core.vo;
+
+import com.napzak.domain.store.core.entity.enums.Role;
+
+import lombok.Getter;
+
+@Getter
+public class StoreSession {
+	private final Long id;
+	private final Role role;
+
+	public StoreSession(Long id, Role role) {
+		this.id = id;
+		this.role = role;
+	}
+
+	public static StoreSession of(Long id, Role role) {
+		return new StoreSession(id, role);
+	}
+}

--- a/src/main/java/com/napzak/global/auth/annotation/AuthorizedRole.java
+++ b/src/main/java/com/napzak/global/auth/annotation/AuthorizedRole.java
@@ -1,0 +1,16 @@
+package com.napzak.global.auth.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.napzak.domain.store.core.entity.enums.Role;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface AuthorizedRole {
+	Role[] value();
+}

--- a/src/main/java/com/napzak/global/auth/aop/AuthorizedRoleAspect.java
+++ b/src/main/java/com/napzak/global/auth/aop/AuthorizedRoleAspect.java
@@ -1,0 +1,95 @@
+package com.napzak.global.auth.aop;
+
+import com.napzak.domain.store.core.entity.enums.Role;
+import com.napzak.domain.store.core.vo.StoreSession;
+import com.napzak.global.auth.annotation.AuthorizedRole;
+import com.napzak.global.auth.context.StoreSessionContextHolder;
+import com.napzak.global.auth.role.RoleProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class AuthorizedRoleAspect {
+
+	private final List<RoleProvider> roleProviders;
+
+	@Before("@annotation(com.napzak.global.auth.annotation.AuthorizedRole) || @within(com.napzak.global.auth.annotation.AuthorizedRole)")
+	public void checkRole(JoinPoint joinPoint) {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication == null || !authentication.isAuthenticated()) {
+			throw new AccessDeniedException("인증 정보가 없습니다.");
+		}
+
+		Object principal = authentication.getPrincipal();
+		String authType = authentication.getClass().getSimpleName();
+		Long userId = extractUserId(principal);
+
+		AuthorizedRole authorizedRole = getAuthorizedRole(joinPoint);
+
+		for (RoleProvider provider : roleProviders) {
+			if (!provider.supports(authType)) continue;
+
+			Role role = provider.provideRole(userId);
+			StoreSessionContextHolder.clear();
+			StoreSessionContextHolder.set(StoreSession.of(userId, role));
+
+			if (Arrays.asList(authorizedRole.value()).contains(role)) {
+				return; // 접근 허용
+			}
+			throw new AccessDeniedException("접근 권한이 없습니다. 현재 역할: " + role);
+		}
+
+		throw new AccessDeniedException("지원되지 않는 인증 유형: " + authType);
+	}
+
+	private AuthorizedRole getAuthorizedRole(JoinPoint joinPoint) {
+		MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+		AuthorizedRole authorizedRole = signature.getMethod().getAnnotation(AuthorizedRole.class);
+
+		if (authorizedRole == null) {
+			authorizedRole = joinPoint.getTarget().getClass().getAnnotation(AuthorizedRole.class);
+		}
+
+		if (authorizedRole == null) {
+			throw new AccessDeniedException("권한 정보가 없습니다.");
+		}
+
+		return authorizedRole;
+	}
+
+
+	private Long extractUserId(Object principal) {
+		if (principal instanceof Long l) {
+			return l;
+		}
+		if (principal instanceof String s) {
+			try {
+				return Long.parseLong(s);
+			} catch (NumberFormatException e) {
+				throw new AccessDeniedException("유효하지 않은 사용자 정보 형식입니다.");
+			}
+		}
+		throw new AccessDeniedException("유효하지 않은 사용자 정보입니다.");
+	}
+
+	@After("@annotation(com.napzak.global.auth.annotation.AuthorizedRole) || @within(com.napzak.global.auth.annotation.AuthorizedRole)")
+	public void clearContext() {
+		StoreSessionContextHolder.clear();
+	}
+}

--- a/src/main/java/com/napzak/global/auth/context/StoreContextHolder.java
+++ b/src/main/java/com/napzak/global/auth/context/StoreContextHolder.java
@@ -1,0 +1,19 @@
+package com.napzak.global.auth.context;
+
+import com.napzak.domain.store.core.vo.Store;
+
+public class StoreContextHolder {
+	private static final ThreadLocal<Store> context = new ThreadLocal<>();
+
+	public static void set(Store store) {
+		context.set(store);
+	}
+
+	public static Store get() {
+		return context.get();
+	}
+
+	public static void clear() {
+		context.remove();
+	}
+}

--- a/src/main/java/com/napzak/global/auth/context/StoreSessionContextHolder.java
+++ b/src/main/java/com/napzak/global/auth/context/StoreSessionContextHolder.java
@@ -1,0 +1,13 @@
+package com.napzak.global.auth.context;
+
+import com.napzak.domain.store.core.vo.StoreSession;
+
+public class StoreSessionContextHolder {
+	private static final ThreadLocal<StoreSession> context = new ThreadLocal<>();
+
+	public static void set(StoreSession session) { context.set(session); }
+
+	public static StoreSession get() { return context.get(); }
+
+	public static void clear() { context.remove(); }
+}

--- a/src/main/java/com/napzak/global/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/napzak/global/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -93,12 +93,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		if (role == Role.ADMIN) {
 			log.info("Creating AdminAuthentication for storeId: {}", storeId);
 			return new AdminAuthentication(storeId.toString(), null, authorities);
-		} else if (role == Role.STORE || role == Role.ONBOARDING || role == Role.WITHDRAWN)  {
-			log.info("Creating StoreAuthentication for storeId: {}", storeId);
+		} else {
+			log.info("Creating MemberAuthentication for storeId: {}", storeId);
 			return new MemberAuthentication(storeId.toString(), null, authorities);
 		}
-		log.error("Unknown role: {}", role);
-		throw new IllegalArgumentException("Unknown role: " + role);
 	}
 
 	private String getJwtFromRequest(HttpServletRequest request) {

--- a/src/main/java/com/napzak/global/auth/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/com/napzak/global/auth/jwt/provider/JwtTokenProvider.java
@@ -7,6 +7,7 @@ import java.util.Date;
 import javax.crypto.SecretKey;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Service;
@@ -95,7 +96,12 @@ public class JwtTokenProvider {
 		String enumValue = roleName.replace("ROLE_", "");
 		log.info("Final role after processing: {}", enumValue);
 
-		return Role.valueOf(enumValue.toUpperCase());
+		try{
+			return Role.valueOf(enumValue.toUpperCase());
+		} catch (IllegalArgumentException e) {
+			log.error("Unknown role in JWT: {}", enumValue);
+			throw new AccessDeniedException("Unknown role in JWT: " + enumValue);
+		}
 	}
 
 	private String issueToken(final Authentication authentication, final long expiredTime) {

--- a/src/main/java/com/napzak/global/auth/role/RoleProvider.java
+++ b/src/main/java/com/napzak/global/auth/role/RoleProvider.java
@@ -1,0 +1,8 @@
+package com.napzak.global.auth.role;
+
+import com.napzak.domain.store.core.entity.enums.Role;
+
+public interface RoleProvider {
+	boolean supports(String authenticationType);
+	Role provideRole(Long id);
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #79 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- API 컨트롤러에 `@AuthorizedRole` 어노테이션을 적용해 Role 단위 접근 제어를 명시적으로 선언할 수 있도록 개선했습니다.
- `AuthorizedRoleAspect` 를 통해 JWT 인증 후 실시간으로 DB에서 Role 을 조회해 인가 검증이 이뤄지도록 AOP 로직을 작성했습니다.
- `StoreSession` VO 와 `StoreSessionContextHolder` 를 추가하여 필수 세션 정보(`storeId`, `role`)를 thread-safe 하게 컨트롤러에서 주입해 사용할 수 있도록 분리했습니다.
- `RoleProvider` 인터페이스 + `StoreRoleProvider` 구현체를 도입해 인증 타입별 Role 제공 방식을 유연하게 구성했습니다.
- JWT 파싱 시 Unknown Role 이 발생하면 `AccessDeniedException` 으로 명시적으로 차단되도록 보완하고, `JwtAuthenticationFilter` 에서 Unknown Role 처리 방식을 단순화하여 허용되지 않은 Role 은 기본적으로 `MemberAuthentication` 으로 통과되지 않도록 리팩토링했습니다.
- 인증/인가 실패 시 `GlobalExceptionHandler` 가 403 으로 핸들링되도록 예외 흐름을 정비했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

- JWT 토큰에 포함된 Role 과 DB의 Role 간 불일치 상황에서도 인가가 최신 Role 기준으로 동작하도록 흐름을 재점검했습니다.
- `@Before` 시점에서 `AuthorizedRole` 어노테이션이 null 이 되는 문제를 `MethodSignature` 로 해결했습니다.
- `RoleProvider` 가 지원하지 않는 인증 유형이 발생할 경우 인가 실패로 안전하게 차단되도록 로직 순서를 조정했습니다.

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
### 허가된 role인 경우
<img width="442" alt="image" src="https://github.com/user-attachments/assets/b3b0c6fb-0a2e-497a-a387-0de802795958" />

### 허가되지 않은 role인 경우
<img width="434" alt="image" src="https://github.com/user-attachments/assets/23daae05-74dc-427e-bbd6-dff40a86ed7a" />
<img width="438" alt="image" src="https://github.com/user-attachments/assets/07b02ce1-12e0-4ede-8979-3a97ffb99168" />

### 정의되지 않은 rold인 경우
<img width="434" alt="image" src="https://github.com/user-attachments/assets/988bb18a-23e2-4f15-aa79-d680867451d3" />

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->
- Role 이 변경된 경우 JWT 토큰 재발급 정책(강제 만료/블랙리스트) 설계는 별도 이슈로 진행 예정

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
