### PR TITLE
[fix] #120 - Interest, Token parameter name binding issue 해결

### DIFF
--- a/api-server/build.gradle
+++ b/api-server/build.gradle
@@ -73,6 +73,7 @@ tasks.named('bootJar') {                   // fat-jar 이름 고정
 def queryDslSrcDir = 'src/main/generated/querydsl/'
 
 tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += "-parameters"
     options.getGeneratedSourceOutputDirectory().set(file(queryDslSrcDir))
 }
 

--- a/common-module/src/main/java/com/napzak/common/auth/jwt/repository/TokenRepository.java
+++ b/common-module/src/main/java/com/napzak/common/auth/jwt/repository/TokenRepository.java
@@ -3,12 +3,13 @@ package com.napzak.common.auth.jwt.repository;
 import java.util.Optional;
 
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 import com.napzak.common.auth.redis.Token;
 
 public interface TokenRepository extends CrudRepository<Token, Long> {
 
-	Optional<Token> findByRefreshToken(final String refreshToken);
+	Optional<Token> findByRefreshToken(@Param("refreshToken") String refreshToken);
 
 	Optional<Token> findById(final Long id);
 }

--- a/common-module/src/main/java/com/napzak/common/auth/redis/Token.java
+++ b/common-module/src/main/java/com/napzak/common/auth/redis/Token.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 
 @RedisHash(value = "refreshToken", timeToLive = 1209600)
 @Getter
-@Builder
 public class Token {
 
 	@Id
@@ -18,10 +17,14 @@ public class Token {
 	@Indexed
 	private String refreshToken;
 
-	public static Token of(final Long id, final String refreshToken) {
-		return Token.builder()
-			.id(id)
-			.refreshToken(refreshToken)
-			.build();
+	public Token() {}
+
+	public Token(Long id, String refreshToken) {
+		this.id = id;
+		this.refreshToken = refreshToken;
+	}
+
+	public static Token of(Long id, String refreshToken) {
+		return new Token(id, refreshToken);
 	}
 }

--- a/core-domain/src/main/java/com/napzak/domain/product/repository/ProductRepository.java
+++ b/core-domain/src/main/java/com/napzak/domain/product/repository/ProductRepository.java
@@ -20,7 +20,7 @@ import jakarta.persistence.LockModeType;
 public interface ProductRepository extends JpaRepository<ProductEntity, Long>, ProductRepositoryCustom {
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("SELECT p FROM ProductEntity p where p.id = :productId")
-	Optional<ProductEntity> lockById(Long productId);
+	Optional<ProductEntity> lockById(@Param("productId") Long productId);
 
 	@Modifying
 	@Query("""


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #120 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
### 📌 변경 내용 요약
- build.gradle
→ -parameters 컴파일 옵션 추가 (메서드 파라미터 이름 보존)
- Token.java
→ Redis 객체에서 파라미터 바인딩 오류 방지를 위해 @Builder 제거 및 생성자 명시
- TokenRepository.java
→ findByRefreshToken 메서드에 @Param("refreshToken") 추가
- ProduceRepository.java
→ 파라미터 이름 매핑 오류 방지를 위해 @Param("productId") 명시

### 🧯 이슈 원인
Spring Data (JPA/Redis)에서 메서드 파라미터 이름이 리플렉션으로 유실되어
아래와 같은 예외 발생:
```
Parameter org.springframework.data.mapping.Parameter@xxxx does not have a name
```
원인은 다음과 같은 조건이 충족되지 않아서:
- 컴파일 시 -parameters 옵션 누락
- Redis 객체에서 @Builder 사용 → 생성자 파라미터 이름 유실
- Repository 메서드에서 @Param 생략

### ✅ 해결 방안
- Token 도메인에서 @Builder 제거하고 기본 생성자 추가
- 모든 repository 쿼리 메서드에 @Param 명시 (TokenRepository, ProduceRepository)
- 컴파일러에 -parameters 옵션 추가하여 JDK 수준에서 파라미터 이름 보존

### 🔎 테스트 결과
- Redis 기반 findByRefreshToken 호출 정상 작동
- JPA 기반 findByProductId 등 @Param 추가된 쿼리 정상 바인딩
- /api/v1/stores/refresh-token 요청 500 오류 → 200 OK 정상 응답 확인

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
- Redis 객체에는 Builder 사용을 피하는 게 안정적입니다
- 추후 공통 Redis 모델에도 동일한 생성자 패턴을 적용 검토 바랍니다
- @Param 누락 시 런타임 오류가 발생하므로, 명시적 작성 습관 권장합니다