### PR TITLE
[refactor] #122 - 채팅 기능 예외 처리: 자신의 상품에 대한 채팅 요청 차단

### DIFF
--- a/api-server/src/main/java/com/napzak/api/domain/product/controller/ProductController.java
+++ b/api-server/src/main/java/com/napzak/api/domain/product/controller/ProductController.java
@@ -699,6 +699,7 @@ public class ProductController implements ProductApi {
 		@CurrentMember Long currentStoreId
 	) {
 		ProductWithFirstPhoto product = productService.getProductChatInfo(productId);
+		if(currentStoreId.equals(product.getStoreId())) throw new NapzakException(ProductErrorCode.PRODUCT_CHAT_SELF_REQUEST_NOT_ALLOWED);
 		Store store = productStoreFacade.getStoreById(product.getStoreId());
 		String genreName = productGenreFacade.getGenreName(product.getGenreId());
 		Long roomId = productChatFacade.findCommonRoomIdByStores(

--- a/core-domain/src/main/java/com/napzak/domain/product/code/ProductErrorCode.java
+++ b/core-domain/src/main/java/com/napzak/domain/product/code/ProductErrorCode.java
@@ -15,6 +15,7 @@ public enum ProductErrorCode implements BaseErrorCode {
 	*/
 	INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 커서입니다."),
 	PRODUCT_PHOTO_SEQUENCE_DUPLICATED(HttpStatus.BAD_REQUEST, "사진 순서는 중복될 수 없습니다."),
+	PRODUCT_CHAT_SELF_REQUEST_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "자신의 상품에는 채팅 정보 조회를 요청할 수 없습니다."),
 
 	/*
 	403 Forbidden


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #122 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

- 자신이 등록한 상품에 대해 채팅 정보를 요청하는 경우를 방지하는 로직 추가
- 실제 서비스에서는 발생 가능성이 낮지만, 잘못된 요청에 대비해 방어 코드 적용
- ProductService.getProductChatInfo() 내부에 storeId 비교 후 예외 발생하도록 처리
- 신규 예외 코드 추가:
PRODUCT_CHAT_SELF_REQUEST_NOT_ALLOWED (400): 자신의 상품에는 채팅을 요청할 수 없습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
