### PR TITLE
[chore] #124 - MessageMapping 경로 변경

### DIFF
--- a/chat-server/build.gradle
+++ b/chat-server/build.gradle
@@ -1,4 +1,4 @@
-// api-server build.gradle
+// chat-server build.gradle
 plugins {
     id 'org.springframework.boot'
 }
@@ -36,6 +36,8 @@ dependencies {
     // Spring Security for WebSocket
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.security:spring-security-messaging'
+
+    implementation 'com.fasterxml.jackson.module:jackson-modules-java8:2.17.0'
 }
 
 jar { enabled = false }

--- a/chat-server/src/main/java/com/napzak/chat/domain/chat/api/controller/ChatWebSocketController.java
+++ b/chat-server/src/main/java/com/napzak/chat/domain/chat/api/controller/ChatWebSocketController.java
@@ -30,12 +30,12 @@ public class ChatWebSocketController {
 	private final ChatPushFacade chatPushFacade;
 	private final SimpMessagingTemplate messagingTemplate;
 
-	@MessageMapping("/chat.send")
+	@MessageMapping("/chat/send")
 	public void sendMessage(ChatMessageRequest request, SimpMessageHeaderAccessor headerAccessor) {
 		// 현재 유저 정보
 		StoreSession session = (StoreSession) headerAccessor.getSessionAttributes().get("storeSession");
 		if (session == null) {
-			log.warn("storeSession is null! rejecting");
+			log.info("storeSession is null! rejecting");
 			return;
 		}
 		log.info("📨 Received chat.send: {}", request);

--- a/chat-server/src/main/resources/static/ws-test.html
+++ b/chat-server/src/main/resources/static/ws-test.html
@@ -128,7 +128,7 @@
             content,
             metadata: null
         };
-        client.send('/pub/chat.send', {}, JSON.stringify(payload));
+        client.send('/pub/chat/send', {}, JSON.stringify(payload));
         log(`➡️ SENT: ${JSON.stringify(payload)}`);
     }
 


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #124 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- MessageMapping 경로 변경 (/chat.send -> /chat/send)
- jackson-modules-java8:2.17.0 의존성 추가

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 채팅 메시지 전송 경로가 `/chat.send`에서 `/chat/send`로 변경되어 WebSocket 메시지 전송이 정상적으로 동작하도록 수정되었습니다.
  * 관련 테스트 페이지의 메시지 전송 경로도 `/pub/chat/send`로 일치하도록 수정되었습니다.

* **기타**
  * 내부 로그 레벨이 경고에서 정보로 조정되었습니다.
  * 빌드 설정에 새로운 Jackson Java 8 모듈 의존성이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->