### PR TITLE
[fix] #128 - 상품 개수 불일치 문제 해결

### DIFF
--- a/api-server/src/main/java/com/napzak/api/domain/product/ProductStoreFacade.java
+++ b/api-server/src/main/java/com/napzak/api/domain/product/ProductStoreFacade.java
@@ -23,11 +23,6 @@ public class ProductStoreFacade {
 		return storeRetriever.findStoreByStoreId(storeId);
 	}
 
-	public StoreStatus getStoreStatusByStoreId(Long storeId) {
-
-		return storeRetriever.getStoreStatusDtoById(storeId);
-	}
-
 	public List<Long> getGenrePreferenceIds(Long storeId) {
 		return genrePreferenceRetriever.getGenrePreferenceIds(storeId);
 	}

--- a/api-server/src/main/java/com/napzak/api/domain/product/controller/ProductController.java
+++ b/api-server/src/main/java/com/napzak/api/domain/product/controller/ProductController.java
@@ -443,7 +443,19 @@ public class ProductController implements ProductApi {
 			.map(ProductPhotoDto::from)
 			.toList();
 
-		StoreStatus storeStatus = productStoreFacade.getStoreStatusByStoreId(product.getStoreId());
+		Store productOwner = productStoreFacade.getStoreById(product.getStoreId());
+		int productOwnerSellCount = productService.countByStoreIdAndTradeTypeAndIsVisibleTrue(productOwner.getId(),
+			TradeType.SELL);
+		int productOwnerBuyCount = productService.countByStoreIdAndTradeTypeAndIsVisibleTrue(productOwner.getId(),
+			TradeType.BUY);
+
+		StoreStatus storeStatus = StoreStatus.from(
+			productOwner.getId(),
+			productOwner.getPhoto(),
+			productOwner.getNickname(),
+			productOwnerSellCount,
+			productOwnerBuyCount
+		);
 
 		// List<Review> reviewList = productReviewFacade.findAllByStoreId(product.getStoreId());
 		//

--- a/api-server/src/main/java/com/napzak/api/domain/product/service/ProductService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/product/service/ProductService.java
@@ -323,6 +323,10 @@ public class ProductService {
 		productReportSaver.save(reporterId, product, photoList, title, description, contact);
 	}
 
+	public int countByStoreIdAndTradeTypeAndIsVisibleTrue(Long storeId, TradeType tradeType) {
+		return productRetriever.countProductsByStoreIdAndTradeType(storeId, tradeType);
+	}
+
 	private ProductPagination retrieveAndPreparePagination(
 		ProductRetrieval retrievalLogic,
 		int size

--- a/core-domain/src/main/java/com/napzak/domain/store/crud/store/StoreRetriever.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/crud/store/StoreRetriever.java
@@ -48,11 +48,6 @@ public class StoreRetriever {
 	}
 
 	@Transactional(readOnly = true)
-	public StoreStatus getStoreStatusDtoById(final Long storeId) {
-		return storeRepository.findStoreStatusById(storeId);
-	}
-
-	@Transactional(readOnly = true)
 	public Store findBySocialTypeAndSocialId(String socialId, SocialType socialType) {
 		StoreEntity storeEntity = storeRepository.findBySocialTypeAndSocialId(socialId, socialType)
 			.orElseThrow(() -> new NapzakException(StoreErrorCode.STORE_NOT_FOUND));

--- a/core-domain/src/main/java/com/napzak/domain/store/repository/StoreRepository.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/repository/StoreRepository.java
@@ -18,21 +18,6 @@ public interface StoreRepository extends JpaRepository<StoreEntity, Long> {
 	Optional<StoreEntity> findBySocialTypeAndSocialId(@Param("socialId") String socialId,
 		@Param("socialType") SocialType socialType);
 
-	@Query("""
-			SELECT new com.napzak.domain.store.vo.StoreStatus(
-			s.id,
-			s.photo,
-			s.nickname,
-			COALESCE(SUM(CASE WHEN p.tradeType = 'SELL' THEN 1 ELSE 0 END), 0),
-			COALESCE(SUM(CASE WHEN p.tradeType = 'BUY' THEN 1 ELSE 0 END), 0)
-			)
-			FROM StoreEntity s
-			LEFT JOIN ProductEntity p ON s.id = p.storeId
-			WHERE s.id = :storeId
-			GROUP BY s.id, s.nickname
-		""")
-	StoreStatus findStoreStatusById(@Param("storeId") Long storeId);
-
 	@Query("SELECT u.nickname FROM StoreEntity u WHERE u.id = :storeId")
 	String findNicknameById(@Param("storeId") Long storeId);
 

--- a/core-domain/src/main/java/com/napzak/domain/store/vo/StoreStatus.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/vo/StoreStatus.java
@@ -4,15 +4,15 @@ public record StoreStatus(
 	Long userId,
 	String storePhoto,
 	String nickname,
-	Long totalSellCount,
-	Long totalBuyCount
+	int totalSellCount,
+	int totalBuyCount
 ) {
 	public static StoreStatus from(
 		Long userId,
 		String storePhoto,
 		String nickname,
-		Long totalSellCount,
-		Long totalBuyCount
+		int totalSellCount,
+		int totalBuyCount
 	) {
 		return new StoreStatus(userId, storePhoto, nickname, totalSellCount, totalBuyCount);
 	}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #번호

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
상품 상세보기 하단에 표시되는 상점 정보의총 상품 갯수 관련하여 
기존 해당 상점의 isVisible이 false인 상품들까지 포함하여 count하고 있었습니다.

마이페이지 조회에 사용되는 로직을 활용하여 수정하였습니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 상품 상세 정보에서 매장 상태 정보가 보다 정확하게 표시되도록 개선되었습니다.

* **기능 개선**
  * 매장 상품 개수 집계 방식이 변경되어, 판매 및 구매 상품 수가 더욱 명확하게 제공됩니다.

* **기타**
  * 매장 상태 정보의 일부 수치 데이터 타입이 변경되어 성능과 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->