### PR TITLE
[feat] #127 - 푸쉬 테스트 REST api 구현

### DIFF
--- a/chat-server/src/main/java/com/napzak/chat/domain/push/api/code/PushSuccessCode.java
+++ b/chat-server/src/main/java/com/napzak/chat/domain/push/api/code/PushSuccessCode.java
@@ -16,6 +16,7 @@ public enum PushSuccessCode implements BaseSuccessCode {
 	PUSH_SETTING_RETRIEVE_SUCCESS(HttpStatus.OK, "알림 설정이 조회되었습니다."),
 	PUSH_TOKEN_DELETE_SUCCESS(HttpStatus.OK, "푸시 토큰이 삭제되었습니다."),
 	PUSH_SETTING_UPDATE_SUCCESS(HttpStatus.OK, "알림 설정이 변경되었습니다."),
+	PUSH_TEST_SUCCESS(HttpStatus.OK, "푸시 테스트 전송이 성공하였습니다."),
 
 	/*
 	201 Created

--- a/chat-server/src/main/java/com/napzak/chat/domain/push/api/controller/PushTokenController.java
+++ b/chat-server/src/main/java/com/napzak/chat/domain/push/api/controller/PushTokenController.java
@@ -84,13 +84,20 @@ public class PushTokenController {
 		@CurrentMember Long storeId,
 		@RequestBody @Valid PushTestRequest request
 	) {
-		// fcmPushSender.sendMessage(
-		// 	storeId,
-		// 	request.deviceToken(),
-		// 	request.title(),
-		// 	request.body(),
-		// 	request.data() != null ? request.data() : Map.of()
-		// );
+		String body = switch (request.messageType()) {
+			case TEXT -> request.notification().body();
+			case IMAGE -> "(사진)";
+			default -> null;
+		};
+
+			fcmPushSender.sendMessage(
+				request.opponentId(),
+				request.token(),
+				request.notification().title(),
+				body,
+				Map.of("type", "chat", "roomId", String.valueOf(request.data().roomId()))
+		);
+
 		return ResponseEntity.ok(SuccessResponse.of(PushSuccessCode.PUSH_TEST_SUCCESS));
 	}
 }

--- a/chat-server/src/main/java/com/napzak/chat/domain/push/api/controller/PushTokenController.java
+++ b/chat-server/src/main/java/com/napzak/chat/domain/push/api/controller/PushTokenController.java
@@ -1,5 +1,7 @@
 package com.napzak.chat.domain.push.api.controller;
 
+import java.util.Map;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,12 +13,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.napzak.chat.domain.push.api.code.PushSuccessCode;
+import com.napzak.chat.domain.push.api.dto.request.PushTestRequest;
 import com.napzak.chat.domain.push.api.dto.request.PushTokenRegisterRequest;
 import com.napzak.chat.domain.push.api.dto.request.PushTokenSettingUpdateRequest;
 import com.napzak.chat.domain.push.api.dto.response.PushSettingResponse;
 import com.napzak.chat.domain.push.api.service.PushTokenService;
 import com.napzak.common.auth.annotation.CurrentMember;
 import com.napzak.common.exception.dto.SuccessResponse;
+import com.napzak.domain.push.util.FcmPushSender;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +31,8 @@ import lombok.RequiredArgsConstructor;
 public class PushTokenController {
 
 	private final PushTokenService pushTokenService;
+	//테스트용
+	private final FcmPushSender fcmPushSender;
 
 	@PostMapping
 	public ResponseEntity<SuccessResponse<Void>> registerPushToken(
@@ -71,5 +77,20 @@ public class PushTokenController {
 	) {
 		pushTokenService.deletePushToken(storeId, deviceToken);
 		return ResponseEntity.ok(SuccessResponse.of(PushSuccessCode.PUSH_TOKEN_DELETE_SUCCESS));
+	}
+
+	@PostMapping("/test")
+	public ResponseEntity<SuccessResponse<Void>> sendTestPush(
+		@CurrentMember Long storeId,
+		@RequestBody @Valid PushTestRequest request
+	) {
+		// fcmPushSender.sendMessage(
+		// 	storeId,
+		// 	request.deviceToken(),
+		// 	request.title(),
+		// 	request.body(),
+		// 	request.data() != null ? request.data() : Map.of()
+		// );
+		return ResponseEntity.ok(SuccessResponse.of(PushSuccessCode.PUSH_TEST_SUCCESS));
 	}
 }

--- a/chat-server/src/main/java/com/napzak/chat/domain/push/api/controller/PushTokenController.java
+++ b/chat-server/src/main/java/com/napzak/chat/domain/push/api/controller/PushTokenController.java
@@ -26,7 +26,9 @@ import com.napzak.domain.push.util.FcmPushSender;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequestMapping("api/v1/push-tokens")
 @RequiredArgsConstructor
@@ -100,7 +102,12 @@ public class PushTokenController {
 				body,
 				Map.of("type", "chat", "roomId", String.valueOf(request.data().roomId()))
 			);
-		} catch (Exception e) { throw new NapzakException(PushErrorCode.PUSH_DELIVERY_FAILED); }
+
+			log.info("테스트 푸시 전송 성공 - storeId: {}, opponentId: {}", storeId, request.opponentId());
+
+		} catch (Exception e) {
+			log.error("테스트 푸시 전송 실패 - storeId: {}, opponentId: {}, error: {}", storeId, request.opponentId(), e.getMessage(), e);
+			throw new NapzakException(PushErrorCode.PUSH_DELIVERY_FAILED); }
 
 		return ResponseEntity.ok(SuccessResponse.of(PushSuccessCode.PUSH_TEST_SUCCESS));
 	}

--- a/chat-server/src/main/java/com/napzak/chat/domain/push/api/dto/request/PushTestRequest.java
+++ b/chat-server/src/main/java/com/napzak/chat/domain/push/api/dto/request/PushTestRequest.java
@@ -1,0 +1,13 @@
+package com.napzak.chat.domain.push.api.dto.request;
+
+import java.util.Map;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PushTestRequest(
+	@NotNull String deviceToken,
+	@NotNull String title,
+	@NotNull String body,
+	Map<String, String> data
+) {
+}

--- a/chat-server/src/main/java/com/napzak/chat/domain/push/api/dto/request/PushTestRequest.java
+++ b/chat-server/src/main/java/com/napzak/chat/domain/push/api/dto/request/PushTestRequest.java
@@ -2,12 +2,24 @@ package com.napzak.chat.domain.push.api.dto.request;
 
 import java.util.Map;
 
+import com.napzak.domain.chat.entity.enums.MessageType;
+
 import jakarta.validation.constraints.NotNull;
 
 public record PushTestRequest(
-	@NotNull String deviceToken,
-	@NotNull String title,
-	@NotNull String body,
-	Map<String, String> data
+	@NotNull Long opponentId,
+	@NotNull MessageType messageType,
+	@NotNull String token,
+	@NotNull Notification notification,
+	@NotNull Data data
 ) {
+	public record Notification(
+		@NotNull String title,
+		@NotNull String body
+	) {}
+
+	public record Data(
+		@NotNull String type,
+		@NotNull String roomId
+	) {}
 }

--- a/core-domain/src/main/java/com/napzak/domain/push/code/PushErrorCode.java
+++ b/core-domain/src/main/java/com/napzak/domain/push/code/PushErrorCode.java
@@ -13,6 +13,7 @@ public enum PushErrorCode implements BaseErrorCode {
 	/*
 	400 Bad Request
 	*/
+	TYPE_NOT_SERVICED(HttpStatus.BAD_REQUEST, "지원하지 않는 content 타입입니다."),
 
 	/*
 	404 Not Found
@@ -22,6 +23,7 @@ public enum PushErrorCode implements BaseErrorCode {
 	/*
 	500 Internal Server Error
 	 */
+	PUSH_DELIVERY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "푸시알림 전송에 실패하였습니다."),
 	PUSH_UNDELIVERED(HttpStatus.INTERNAL_SERVER_ERROR, "푸시알림 전송에 실패하여 재전송합니다."),
 	;
 

--- a/core-domain/src/main/java/com/napzak/domain/push/util/FcmPushSender.java
+++ b/core-domain/src/main/java/com/napzak/domain/push/util/FcmPushSender.java
@@ -34,11 +34,14 @@ public class FcmPushSender {
 				.build();
 
 			firebaseMessaging.send(message);
+			log.info("푸시 메시지가 보내졌음." + message);
 		} catch (FirebaseMessagingException e) {
 			if (e.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED) {
 				// DB에서 무효 토큰 삭제
 				pushDeviceTokenRemover.delete(storeId, deviceToken);
+				log.warn("무효 토큰 삭제됨.");
 			} else {
+				log.warn("FCM push 실패: ", e);
 				log.warn("FCM Push 실패: {}", e.getMessagingErrorCode());
 			}
 		}

--- a/core-domain/src/main/java/com/napzak/domain/push/util/FcmPushSender.java
+++ b/core-domain/src/main/java/com/napzak/domain/push/util/FcmPushSender.java
@@ -34,14 +34,14 @@ public class FcmPushSender {
 				.build();
 
 			firebaseMessaging.send(message);
-			log.info("푸시 메시지가 보내졌음." + message);
+
+			//log.info("푸시 메시지가 보내졌음." + message);
 		} catch (FirebaseMessagingException e) {
 			if (e.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED) {
 				// DB에서 무효 토큰 삭제
 				pushDeviceTokenRemover.delete(storeId, deviceToken);
 				log.warn("무효 토큰 삭제됨.");
 			} else {
-				log.warn("FCM push 실패: ", e);
 				log.warn("FCM Push 실패: {}", e.getMessagingErrorCode());
 			}
 		}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #127

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
테스트를 위한 푸시알림 전송 post api를 작성하였습니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="682" height="643" alt="image" src="https://github.com/user-attachments/assets/6222fc91-9a26-477b-a1e1-0adee4c9fbff" />

성공적으로 send 시 로그 출력하도록 하였고, api 요청 시 성공 로그 출력됨 확인되었습니다.
<img width="671" height="308" alt="image" src="https://github.com/user-attachments/assets/31322d6a-5910-4668-b847-e7a99a94fbe0" />

<img width="519" height="42" alt="image" src="https://github.com/user-attachments/assets/606dcc17-6272-447c-862f-f1041098c252" />


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 테스트 푸시 알림을 전송할 수 있는 새로운 엔드포인트가 추가되었습니다.
  * 테스트 푸시 알림 요청을 위한 새로운 요청 형식이 도입되었습니다.

* **버그 수정**
  * 유효하지 않은 토큰 발생 시 관련 로그가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->