### PR TITLE
[fix] #133 - date 메세지 중복 삽입 이슈 해결 및 일부 채팅 dto 수정

### DIFF
--- a/api-server/src/main/java/com/napzak/api/domain/product/ProductChatFacade.java
+++ b/api-server/src/main/java/com/napzak/api/domain/product/ProductChatFacade.java
@@ -17,4 +17,8 @@ public class ProductChatFacade {
 	public Optional<Long> findCommonRoomIdByStores(Long myStoreId, Long opponentStoreId){
 		return chatParticipantRetriever.findCommonRoomIdByStores(myStoreId, opponentStoreId);
 	}
+
+	public Long findChatOpponentStoreId(Long roomId, Long myStoreId){
+		return chatParticipantRetriever.findOpponentStoreId(roomId, myStoreId);
+	}
 }

--- a/api-server/src/main/java/com/napzak/api/domain/product/dto/response/ProductChatInfoResponse.java
+++ b/api-server/src/main/java/com/napzak/api/domain/product/dto/response/ProductChatInfoResponse.java
@@ -14,7 +14,8 @@ public record ProductChatInfoResponse(
 		ProductWithFirstPhoto product,
 		Store store,
 		String genreName,
-		Long roomId
+		Long roomId,
+		boolean isMyProduct
 	) {
 		boolean isWithdrawn = store.getRole().equals(Role.WITHDRAWN);
 		String nickname = isWithdrawn ? "(탈퇴한 사용자) " + store.getNickname() : store.getNickname();
@@ -26,7 +27,9 @@ public record ProductChatInfoResponse(
 				product.getTitle(),
 				product.getPrice(),
 				product.getIsPriceNegotiable(),
-				genreName
+				genreName,
+				product.getStoreId(),
+				isMyProduct
 			),
 			new StoreInfo(
 				store.getId(),
@@ -38,6 +41,9 @@ public record ProductChatInfoResponse(
 		);
 	}
 
-	public record ProductInfo(Long productId, String photo, TradeType tradeType, String title, int price, Boolean isPriceNegotiable, String genreName) {}
+	public record ProductInfo(
+		Long productId, String photo, TradeType tradeType, String title, int price,
+		Boolean isPriceNegotiable, String genreName, Long productOwnerId, boolean isMyProduct) {}
+
 	public record StoreInfo(Long storeId, String nickname, String storePhoto, boolean isWithdrawn) {}
 }

--- a/chat-server/src/main/java/com/napzak/chat/domain/chat/api/controller/ChatRestController.java
+++ b/chat-server/src/main/java/com/napzak/chat/domain/chat/api/controller/ChatRestController.java
@@ -112,7 +112,7 @@ public class ChatRestController {
 
 		return ResponseEntity.ok(
 			SuccessResponse.of(ChatSuccessCode.CHATROOM_LIST_RETRIEVE_SUCCESS,
-				ChatRoomListResponse.of(summaries, isMessageAllowed))
+				ChatRoomListResponse.of(summaries, storeId, isMessageAllowed))
 		);
 	}
 

--- a/chat-server/src/main/java/com/napzak/chat/domain/chat/api/dto/response/ChatRoomListResponse.java
+++ b/chat-server/src/main/java/com/napzak/chat/domain/chat/api/dto/response/ChatRoomListResponse.java
@@ -6,11 +6,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 public record ChatRoomListResponse(
 	List<ChatRoomSummary> chatRooms,
+	Long currentStoreId,
 
  	@JsonInclude(JsonInclude.Include.NON_NULL)
 	Boolean isMessageAllowed
 ) {
-	public static ChatRoomListResponse of(List<ChatRoomSummary> summaries, Boolean isMessageAllowed) {
+	public static ChatRoomListResponse of(List<ChatRoomSummary> summaries, Long currentStoreId, Boolean isMessageAllowed) {
 		// createdAt 최신순으로 정렬
 		List<ChatRoomSummary> sorted = summaries.stream()
 			.sorted((a, b) -> {
@@ -18,6 +19,6 @@ public record ChatRoomListResponse(
 			})
 			.toList();
 
-		return new ChatRoomListResponse(sorted, isMessageAllowed);
+		return new ChatRoomListResponse(sorted, currentStoreId, isMessageAllowed);
 	}
 }

--- a/chat-server/src/main/resources/static/ws-test.html
+++ b/chat-server/src/main/resources/static/ws-test.html
@@ -128,7 +128,9 @@
             content,
             metadata: null
         };
-        client.send('/pub/chat/send', {}, JSON.stringify(payload));
+        client.send('/pub/chat/send',
+            { 'content-type': 'application/json' },
+            JSON.stringify(payload));
         log(`➡️ SENT: ${JSON.stringify(payload)}`);
     }
 

--- a/core-domain/src/main/java/com/napzak/domain/chat/crud/chatmessage/ChatMessageSaver.java
+++ b/core-domain/src/main/java/com/napzak/domain/chat/crud/chatmessage/ChatMessageSaver.java
@@ -60,16 +60,15 @@ public class ChatMessageSaver {
 	}
 
 	@Transactional
-	public ChatMessage saveDateMessage(Long roomId){
-		ChatMessageEntity entity = ChatMessageEntity.create(
-			roomId, null, MessageType.DATE, null,
-			toJson(Map.of(
-				"type", "DATE",
-				"date", LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy년 M월 d일"))
-			))
-		);
-		chatMessageRepository.save(entity);
-
+	public ChatMessage saveDateMessage(Long roomId) {
+		String messageType = MessageType.DATE.name();
+		String metadata = toJson(Map.of(
+			"type", "DATE",
+			"date", LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy년 M월 d일"))
+		));
+		chatMessageRepository.insertDateMessageIfNotExists(roomId, messageType, metadata);
+		ChatMessageEntity entity = chatMessageRepository.findTodayDateMessage(roomId, messageType)
+			.orElseThrow(() -> new NapzakException(ChatErrorCode.MESSAGE_NOT_FOUND));
 		return ChatMessage.fromEntity(entity);
 	}
 

--- a/core-domain/src/main/java/com/napzak/domain/chat/repository/ChatMessageRepository.java
+++ b/core-domain/src/main/java/com/napzak/domain/chat/repository/ChatMessageRepository.java
@@ -1,9 +1,9 @@
 package com.napzak.domain.chat.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -16,4 +16,35 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, 
 
 	@Query("SELECT MAX(m.id) FROM ChatMessageEntity m WHERE m.roomId = :roomId")
 	Optional<Long> findLastMessageIdByRoomId(@Param("roomId") Long roomId);
+
+	@Modifying
+	@Query(
+		value = """
+			INSERT INTO chat_message (room_id, type, metadata, created_at)
+			VALUES (:roomId, :type, CAST(:metadata AS JSON), NOW(6))
+			ON DUPLICATE KEY UPDATE id = id
+		""",
+		nativeQuery = true
+	)
+	void insertDateMessageIfNotExists(
+		@Param("roomId") Long roomId,
+		@Param("type") String type,
+		@Param("metadata") String metadata
+	);
+
+	@Query(
+		value = """
+			SELECT *
+			FROM chat_message
+			WHERE room_id = :roomId
+			  AND type = :type
+			  AND created_date = CURRENT_DATE()
+			LIMIT 1
+    	""",
+		nativeQuery = true
+	)
+	Optional<ChatMessageEntity> findTodayDateMessage(
+		@Param("roomId") Long roomId,
+		@Param("type") String type
+	);
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #133 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
## DATE 메시지 중복 방지 로직 도입 및 유니크 인덱스 적용
하루에 한 번만 생성되어야 하는 `DATE` 메시지가 연달아 전송될 때 중복 생성되는 이슈를 해결했습니다.  
MySQL에서 partial index(`WHERE type = 'DATE'`)를 지원하지 않아, `가상 컬럼 + 유니크 인덱스` 전략으로 처리했습니다.
### ✅ DB 스키마
- `created_date` (DATE): `created_at`에서 날짜만 추출한 가상 컬럼
- `date_message_flag` (CHAR(1)): `type = 'DATE'`인 경우에만 'Y'로 설정되는 가상 컬럼
- `(room_id, created_date, date_message_flag)` 조합에 대해 유니크 인덱스 추가  
  → **DATE 메시지는 하루에 하나만 허용**

### ✅ 코드 변경
- `insertDateMessageIfNotExists(...)` native query 도입  
  → 중복 발생 시 `ON DUPLICATE KEY UPDATE id = id`로 무시 처리
- 삽입 후 `findTodayDateMessage(...)`로 해당 메시지를 조회하여 DTO 반환
- 기존 `saveDateMessage()`는 남겨두고, 새 방식으로 전환 가능하도록 리팩터링
- 중복 여부 확인 로그 및 예외 대응 추가

### 테스트
- 유니크 인덱스가 중복 DATE 메시지를 차단하는지 확인
- TEXT, IMAGE 등 다른 타입 메시지는 영향을 받지 않음
- `room_id`, `날짜`, `type=DATE` 조합이 중복일 때 insert 무시됨

### 참고
- MySQL의 partial index 미지원 → 가상 컬럼(flag) 활용
- EC2 서버 시간대는 Asia/Seoul 기준으로 설정됨
- created_at 기반으로 created_date 자동 생성

---

## 채팅 관련 정보 조회 dto 및 로직 수정
- response에 productOwnerId, isMyProduct 추가
- storeInfo는 내가 아닌 상대방 상점 정보를 잘 조회하도록 상황별 분기처리

---

## 채팅방 리스트 조회 dto 수정
- 클라 요구사항에 맞게 currentStoreId를 포함하도록 수정

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
