### PR TITLE
[feat] #137 - 채팅방 생성 실시간 알림 기능 구현

### DIFF
--- a/api-server/src/main/java/com/napzak/api/domain/store/code/StoreSuccessCode.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/code/StoreSuccessCode.java
@@ -16,6 +16,7 @@ public enum StoreSuccessCode implements BaseSuccessCode {
 	LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃 성공"),
 	GENRE_PREPERENCE_REGISTER_SUCCESS(HttpStatus.CREATED, "장르 정보 저장 성공"),
 	GET_MYPAGE_INFO_SUCCESS(HttpStatus.OK, "마이페이지 정보 조회 성공"),
+	GET_STORE_ID_SUCCESS(HttpStatus.OK, "상점 id 조회 성공"),
 	GET_STORE_INFO_SUCCESS(HttpStatus.OK, "상점 정보 조회 성공"),
 	GET_SETTING_LINK_SUCCESS(HttpStatus.OK, "설정 링크 조회 성공"),
 	ACCESS_TOKEN_REISSUE_SUCCESS(HttpStatus.OK, "액세스 토큰 재발급 성공"),

--- a/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
@@ -35,13 +35,13 @@ import com.napzak.api.domain.store.dto.response.LoginSuccessResponse;
 import com.napzak.api.domain.store.dto.response.MyPageResponse;
 import com.napzak.api.domain.store.dto.response.OnboardingTermsListResponse;
 import com.napzak.api.domain.store.dto.response.SettingLinkResponse;
+import com.napzak.api.domain.store.dto.response.StoreIdResponse;
 import com.napzak.api.domain.store.dto.response.StoreInfoResponse;
 import com.napzak.api.domain.store.dto.response.StoreProfileModifyResponse;
 import com.napzak.api.domain.store.dto.response.StoreReportResponse;
 import com.napzak.api.domain.store.dto.response.StoreWithdrawResponse;
 import com.napzak.api.domain.store.dto.response.TermsDto;
 import com.napzak.common.auth.annotation.AuthorizedRole;
-import com.napzak.domain.chat.entity.enums.MessageType;
 import com.napzak.domain.chat.entity.enums.SystemMessageType;
 import com.napzak.domain.chat.vo.ChatMessage;
 import com.napzak.domain.external.entity.enums.LinkType;
@@ -143,12 +143,20 @@ public class StoreController implements StoreApi {
 		return ResponseEntity.ok().body(SuccessResponse.of(StoreSuccessCode.LOGOUT_SUCCESS, null));
 	}
 
-	@PostMapping("refresh-token")
+	@PostMapping("/refresh-token")
 	public ResponseEntity<SuccessResponse<AccessTokenGenerateResponse>> reissue(
 		@CookieValue("refreshToken") String refreshToken
 	) {
 		AccessTokenGenerateResponse accessTokenGenerateResponse = authenticationService.generateAccessTokenFromRefreshToken(refreshToken);
 		return ResponseEntity.ok(SuccessResponse.of(StoreSuccessCode.ACCESS_TOKEN_REISSUE_SUCCESS, accessTokenGenerateResponse));
+	}
+
+	@AuthorizedRole({Role.ADMIN, Role.STORE})
+	@GetMapping("/store-id")
+	public ResponseEntity<SuccessResponse<StoreIdResponse>> getStoreId(
+		@CurrentMember final Long currentStoreId
+	) {
+		return ResponseEntity.ok(SuccessResponse.of(StoreSuccessCode.GET_STORE_ID_SUCCESS, StoreIdResponse.of(currentStoreId)));
 	}
 
 	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING})

--- a/api-server/src/main/java/com/napzak/api/domain/store/dto/response/StoreIdResponse.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/dto/response/StoreIdResponse.java
@@ -1,0 +1,9 @@
+package com.napzak.api.domain.store.dto.response;
+
+public record StoreIdResponse(
+	Long storeId
+) {
+	public static StoreIdResponse of(Long storeId) {
+		return new StoreIdResponse(storeId);
+	}
+}

--- a/chat-server/src/main/java/com/napzak/chat/domain/chat/amqp/ChatDlqMessageListener.java
+++ b/chat-server/src/main/java/com/napzak/chat/domain/chat/amqp/ChatDlqMessageListener.java
@@ -28,7 +28,7 @@ public class ChatDlqMessageListener {
 		log.warn("☠️ [DLQ] 최종 실패 메시지: {}", payload);
 
 		// DLQ는 이미 재시도 3회 이상 넘은 것이므로 다시 보내지 않고 알림만.
-		if (payload.retryCount() < 3) {
+		if (payload.retryCount() < MAX_RETRY_COUNT) {
 			// 만약 비즈니스상 다시 보내야 한다면 → Retry Queue로 수동 복귀 가능.
 			ChatMessagePayload retried = ChatMessagePayload.retry(payload);
 			log.info("🔁 DLQ에서 수동 재시도: retryCount = {}", retried.retryCount());

--- a/chat-server/src/main/java/com/napzak/chat/domain/chat/amqp/RabbitMQConfig.java
+++ b/chat-server/src/main/java/com/napzak/chat/domain/chat/amqp/RabbitMQConfig.java
@@ -29,6 +29,8 @@ public class RabbitMQConfig {
 	public static final String ROOM_CREATED_DLQ_QUEUE = "chat.room-created.dlq";
 	public static final String ROOM_CREATED_DLQ_ROUTING_KEY = "chat.room-created.dlq";
 
+	public static final int MAX_RETRY_COUNT = 3;
+
 	// 1️⃣ Exchange
 	@Bean
 	public TopicExchange chatExchange() {

--- a/chat-server/src/main/java/com/napzak/chat/domain/chat/amqp/RoomCreatedDlqListener.java
+++ b/chat-server/src/main/java/com/napzak/chat/domain/chat/amqp/RoomCreatedDlqListener.java
@@ -1,0 +1,32 @@
+package com.napzak.chat.domain.chat.amqp;
+
+import static com.napzak.chat.domain.chat.amqp.RabbitMQConfig.*;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+import com.napzak.domain.chat.vo.RoomCreatedPayload;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RoomCreatedDlqListener {
+	private final RabbitTemplate rabbitTemplate;
+
+	@RabbitListener(queues = ROOM_CREATED_DLQ_QUEUE)
+	public void handle(RoomCreatedPayload payload) {
+		log.warn("☠️ [DLQ] RoomCreatedPayload failed: {}", payload);
+		if (payload.retryCount() < 3) {
+			RoomCreatedPayload retried = RoomCreatedPayload.retry(payload);
+			rabbitTemplate.convertAndSend(EXCHANGE_NAME, ROOM_CREATED_RETRY_ROUTING_KEY, retried);
+			log.info("🔁 DLQ retrying RoomCreatedPayload: {}", retried);
+		} else {
+			log.error("❌ DLQ retry exceeded for RoomCreatedPayload: {}", payload);
+			// Optional: Sentry, Slack, alert
+		}
+	}
+}

--- a/chat-server/src/main/java/com/napzak/chat/domain/chat/amqp/RoomCreatedDlqListener.java
+++ b/chat-server/src/main/java/com/napzak/chat/domain/chat/amqp/RoomCreatedDlqListener.java
@@ -20,7 +20,7 @@ public class RoomCreatedDlqListener {
 	@RabbitListener(queues = ROOM_CREATED_DLQ_QUEUE)
 	public void handle(RoomCreatedPayload payload) {
 		log.warn("☠️ [DLQ] RoomCreatedPayload failed: {}", payload);
-		if (payload.retryCount() < 3) {
+		if (payload.retryCount() < MAX_RETRY_COUNT) {
 			RoomCreatedPayload retried = RoomCreatedPayload.retry(payload);
 			rabbitTemplate.convertAndSend(EXCHANGE_NAME, ROOM_CREATED_RETRY_ROUTING_KEY, retried);
 			log.info("🔁 DLQ retrying RoomCreatedPayload: {}", retried);

--- a/chat-server/src/main/java/com/napzak/chat/domain/chat/amqp/RoomCreatedListener.java
+++ b/chat-server/src/main/java/com/napzak/chat/domain/chat/amqp/RoomCreatedListener.java
@@ -1,0 +1,43 @@
+package com.napzak.chat.domain.chat.amqp;
+
+import static com.napzak.chat.domain.chat.amqp.RabbitMQConfig.ROOM_CREATED_QUEUE;
+import static com.napzak.chat.domain.chat.amqp.RabbitMQConfig.EXCHANGE_NAME;
+import static com.napzak.chat.domain.chat.amqp.RabbitMQConfig.ROOM_CREATED_RETRY_ROUTING_KEY;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import com.napzak.common.exception.NapzakException;
+import com.napzak.domain.chat.code.ChatErrorCode;
+import com.napzak.domain.chat.vo.RoomCreatedPayload;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RoomCreatedListener {
+	private final SimpMessagingTemplate messagingTemplate;
+	private final RabbitTemplate rabbitTemplate;
+
+	@RabbitListener(queues = ROOM_CREATED_QUEUE)
+	public void handle(RoomCreatedPayload payload) {
+		try {
+			String destination = "/queue/chat.room-created." + payload.storeId();
+			messagingTemplate.convertAndSend(destination, payload.roomId().toString());
+			log.info("🚀 Notified store {} about new room {}", payload.storeId(), payload.roomId());
+		} catch (Exception e) {
+			if (payload.retryCount() < 3) {
+				RoomCreatedPayload retried = RoomCreatedPayload.retry(payload);
+				rabbitTemplate.convertAndSend(EXCHANGE_NAME, ROOM_CREATED_RETRY_ROUTING_KEY, retried);
+				log.warn("🔁 Retrying RoomCreatedPayload: {}", retried);
+				return;
+			}
+			log.error("❌ Failed to deliver RoomCreatedPayload after retries: {}", payload, e);
+			throw new NapzakException(ChatErrorCode.MESSAGE_UNDELIVERED);
+		}
+	}
+}

--- a/chat-server/src/main/java/com/napzak/chat/domain/chat/amqp/RoomCreatedListener.java
+++ b/chat-server/src/main/java/com/napzak/chat/domain/chat/amqp/RoomCreatedListener.java
@@ -1,8 +1,6 @@
 package com.napzak.chat.domain.chat.amqp;
 
-import static com.napzak.chat.domain.chat.amqp.RabbitMQConfig.ROOM_CREATED_QUEUE;
-import static com.napzak.chat.domain.chat.amqp.RabbitMQConfig.EXCHANGE_NAME;
-import static com.napzak.chat.domain.chat.amqp.RabbitMQConfig.ROOM_CREATED_RETRY_ROUTING_KEY;
+import static com.napzak.chat.domain.chat.amqp.RabbitMQConfig.*;
 
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -30,7 +28,7 @@ public class RoomCreatedListener {
 			messagingTemplate.convertAndSend(destination, payload.roomId().toString());
 			log.info("🚀 Notified store {} about new room {}", payload.storeId(), payload.roomId());
 		} catch (Exception e) {
-			if (payload.retryCount() < 3) {
+			if (payload.retryCount() < MAX_RETRY_COUNT) {
 				RoomCreatedPayload retried = RoomCreatedPayload.retry(payload);
 				rabbitTemplate.convertAndSend(EXCHANGE_NAME, ROOM_CREATED_RETRY_ROUTING_KEY, retried);
 				log.warn("🔁 Retrying RoomCreatedPayload: {}", retried);

--- a/chat-server/src/main/java/com/napzak/chat/domain/chat/amqp/RoomCreatedSender.java
+++ b/chat-server/src/main/java/com/napzak/chat/domain/chat/amqp/RoomCreatedSender.java
@@ -1,0 +1,22 @@
+package com.napzak.chat.domain.chat.amqp;
+
+import static com.napzak.chat.domain.chat.amqp.RabbitMQConfig.EXCHANGE_NAME;
+import static com.napzak.chat.domain.chat.amqp.RabbitMQConfig.ROOM_CREATED_ROUTING_KEY;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+import com.napzak.domain.chat.vo.RoomCreatedPayload;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RoomCreatedSender {
+	private final RabbitTemplate rabbitTemplate;
+
+	public void send(Long roomId, Long storeId) {
+		RoomCreatedPayload payload = RoomCreatedPayload.from(roomId, storeId);
+		rabbitTemplate.convertAndSend(EXCHANGE_NAME, ROOM_CREATED_ROUTING_KEY, payload);
+	}
+}

--- a/chat-server/src/main/java/com/napzak/chat/domain/chat/api/controller/ChatRestController.java
+++ b/chat-server/src/main/java/com/napzak/chat/domain/chat/api/controller/ChatRestController.java
@@ -64,6 +64,7 @@ public class ChatRestController {
 		@CurrentMember Long senderId
 	){
 		Long roomId = chatRestService.createChatRoom(senderId, request.receiverId(), request.productId());
+		chatWebSocketService.notifyRoomCreated(roomId, List.of(senderId, request.receiverId()));
 		return ResponseEntity.ok(SuccessResponse.of(ChatSuccessCode.CHATROOM_CREATE_SUCCESS, ChatRoomCreateResponse.of(roomId)));
 	}
 

--- a/chat-server/src/main/java/com/napzak/chat/websocket/config/ChatClassMapper.java
+++ b/chat-server/src/main/java/com/napzak/chat/websocket/config/ChatClassMapper.java
@@ -11,9 +11,12 @@ public class ChatClassMapper extends DefaultClassMapper {
 		try {
 			idClassMapping.put("com.napzak.domain.chat.vo.ChatMessagePayload",
 				Class.forName("com.napzak.domain.chat.vo.ChatMessagePayload"));
+			idClassMapping.put("com.napzak.domain.chat.vo.RoomCreatedPayload",
+				Class.forName("com.napzak.domain.chat.vo.RoomCreatedPayload"));
 		} catch (ClassNotFoundException e) {
 			throw new RuntimeException("ChatMessagePayload 클래스 로딩 실패", e);
 		}
 		setIdClassMapping(idClassMapping);
+		setTrustedPackages("com.napzak.domain.chat.vo");
 	}
 }

--- a/chat-server/src/main/java/com/napzak/chat/websocket/config/ChatClassMapper.java
+++ b/chat-server/src/main/java/com/napzak/chat/websocket/config/ChatClassMapper.java
@@ -14,7 +14,7 @@ public class ChatClassMapper extends DefaultClassMapper {
 			idClassMapping.put("com.napzak.domain.chat.vo.RoomCreatedPayload",
 				Class.forName("com.napzak.domain.chat.vo.RoomCreatedPayload"));
 		} catch (ClassNotFoundException e) {
-			throw new RuntimeException("ChatMessagePayload 클래스 로딩 실패", e);
+			throw new RuntimeException("Message Payload 클래스 로딩 실패", e);
 		}
 		setIdClassMapping(idClassMapping);
 		setTrustedPackages("com.napzak.domain.chat.vo");

--- a/chat-server/src/main/java/com/napzak/chat/websocket/config/WebSocketConfig.java
+++ b/chat-server/src/main/java/com/napzak/chat/websocket/config/WebSocketConfig.java
@@ -43,7 +43,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
 	@Override
 	public void configureMessageBroker(MessageBrokerRegistry config) {
-		config.enableStompBrokerRelay("/topic")
+		config.enableStompBrokerRelay("/topic", "/queue", "/user")
 			.setRelayHost(relayHost)
 			.setRelayPort(relayPort)
 			.setClientLogin(relayLogin)
@@ -51,5 +51,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 			.setSystemLogin(systemLogin)
 			.setSystemPasscode(systemPasscode);
 		config.setApplicationDestinationPrefixes("/pub");
+		config.setUserDestinationPrefix("/user");
 	}
 }

--- a/chat-server/src/main/resources/static/ws-test.html
+++ b/chat-server/src/main/resources/static/ws-test.html
@@ -5,7 +5,7 @@
     <title>Napzak Chat WebSocket Tester</title>
     <style>
         body { font-family: sans-serif; margin: 20px; }
-        #log, #chatWindow, #debugWindow {
+        #log, #roomCreatedWindow, #chatWindow, #debugWindow {
             height: 200px;
             overflow-y: auto;
             background: #111;
@@ -155,16 +155,16 @@
     function subscribeRoomCreated() {
         if (!connected) { log("먼저 연결하세요"); return; }
 
-        const storeId = prompt("🔑 내 storeId는?");  // 예: "1"
+        const storeId = prompt("🔑 내 storeId는?");
         client.subscribe(`/queue/chat.room-created.${storeId}`, msg => {
             const roomId = msg.body;
-            log(`🆕 새 채팅방 생성됨! roomId = ${roomId}`);
-            printChat(`🚨 Room created: ${roomId}`);
+            const el = document.getElementById('roomCreatedWindow');
+            el.textContent += `🆕 새 채팅방 생성됨! roomId = ${roomId}\n`;
+            el.scrollTop = el.scrollHeight;
         });
 
         log(`🔔 SUBSCRIBED /queue/chat.room-created.${storeId}`);
     }
-
 </script>
 </body>
 </html>

--- a/chat-server/src/main/resources/static/ws-test.html
+++ b/chat-server/src/main/resources/static/ws-test.html
@@ -44,10 +44,14 @@
     <button onclick="sendMessage()">Send</button>
     <button onclick="subscribePong()">Subscribe Pong</button>
     <button onclick="sendPing()">Ping</button>
+    <button onclick="subscribeRoomCreated()">Subscribe RoomCreated</button>
 </div>
 
 <h3>🟢 Chat Messages</h3>
 <pre id="chatWindow"></pre>
+
+<h3>🆕 Room Created 알림</h3>
+<pre id="roomCreatedWindow"></pre>
 
 <h3>🛠️ Debug Log</h3>
 <pre id="log"></pre>
@@ -147,6 +151,20 @@
         client.send('/pub/ping', {}, {});
         log('🏓 PING');
     }
+
+    function subscribeRoomCreated() {
+        if (!connected) { log("먼저 연결하세요"); return; }
+
+        const storeId = prompt("🔑 내 storeId는?");  // 예: "1"
+        client.subscribe(`/queue/chat.room-created.${storeId}`, msg => {
+            const roomId = msg.body;
+            log(`🆕 새 채팅방 생성됨! roomId = ${roomId}`);
+            printChat(`🚨 Room created: ${roomId}`);
+        });
+
+        log(`🔔 SUBSCRIBED /queue/chat.room-created.${storeId}`);
+    }
+
 </script>
 </body>
 </html>

--- a/core-domain/src/main/java/com/napzak/domain/chat/vo/RoomCreatedPayload.java
+++ b/core-domain/src/main/java/com/napzak/domain/chat/vo/RoomCreatedPayload.java
@@ -1,0 +1,18 @@
+package com.napzak.domain.chat.vo;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RoomCreatedPayload(
+	Long roomId,
+	Long storeId,
+	int retryCount
+) {
+	public static RoomCreatedPayload from(Long roomId, Long storeId) {
+		return new RoomCreatedPayload(roomId, storeId, 0);
+	}
+
+	public static RoomCreatedPayload retry(RoomCreatedPayload payload) {
+		return new RoomCreatedPayload(payload.roomId(), payload.storeId(), payload.retryCount() + 1);
+	}
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #135 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
### 🔔 채팅방 생성 실시간 알림 기능 RabbitMQ 기반으로 구현
- 채팅방 생성 시 참여 유저들에게 실시간으로 알림을 전송하기 위해 /queue/chat.room-created.{storeId} 경로를 사용하는 WebSocket 채널 도입
- 클라이언트는 storeId 조회 후 해당 채널을 구독하여 알림 수신 가능
- 알림 메시지는 RabbitMQ를 통해 브로드캐스트되어 모든 서버에 전파되며, retry/dlq 처리까지 보장
- 메시지는 단일 roomId 문자열 형태로 전송되어 클라이언트는 구독만 하면 별도 파싱 없이 바로 사용 가능

### 📦 시스템 구성 변경
- WebSocketConfig
    - STOMP relay 경로에 /queue 추가 → SimpMessagingTemplate 전파를 위해 필수
- RabbitMQConfig
    - chat.room-created.queue, retry, dlq 구성 추가
    - 기존 채팅 메시지 시스템과 별도 처리 경로 구성

### 💬 실시간 전파 메시지
- 메시지 페이로드: RoomCreatedPayload (roomId, storeId, retryCount)
- queue 구조
    - chat.room-created.queue → chat.room-created.retry → DLQ
- 수신된 메시지는 SimpMessagingTemplate 통해 /queue/chat.room-created.{storeId} 전송됨

### 🧪 테스트 페이지 기능 추가
- HTML 테스트 페이지에서 storeId 기반 채팅방 생성 알림 채널 구독 가능
- 실시간 수신 메시지(roomId)가 테스트 채팅창에 출력됨

### 🆔 storeId 조회 API 제공
- 클라이언트가 WebSocket 연결 시 사용할 수 있도록 인증된 사용자의 storeId 를 반환하는 전용 API 추가
→ `GET /api/v1/stores/store-id`

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 채팅방 생성 시 관련 참여자에게 실시간 알림(WebSocket) 제공.
  * 채팅방 생성 알림을 위한 RabbitMQ 큐 및 재시도/데드레터 처리 기능 추가.
  * WebSocket 테스트 페이지에 "채팅방 생성 알림 구독" 기능 추가.
  * 상점 ID 조회 API 엔드포인트 추가(ADMIN, STORE 권한).
* **버그 수정**
  * 리프레시 토큰 엔드포인트 경로 오타 수정.
* **기타**
  * WebSocket 브로커 설정에 "/queue", "/user" 프리픽스 추가.
  * 메시지 재시도 횟수 상수화 및 관련 로직 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->