### PR TITLE
[feat] #139 - 토큰 재발행 api 구현

### DIFF
--- a/api-server/src/main/java/com/napzak/api/domain/store/code/StoreSuccessCode.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/code/StoreSuccessCode.java
@@ -35,6 +35,7 @@ public enum StoreSuccessCode implements BaseSuccessCode {
 	STORE_REPORT_SUCCESS(HttpStatus.CREATED, "상점이 신고되었습니다."),
 	STORE_WITHDRAW_SUCCESS(HttpStatus.CREATED, "상점 탈퇴가 완료되었습니다."),
 	REGISTER_TERMS_AGREEMENT_SUCCESS(HttpStatus.CREATED, "약관 동의 내용이 저장되었습니다."),
+	TOKENS_REISSUE_SUCCESS(HttpStatus.OK, "토큰 재발행에 성공하였습니다."),
 	;
 
 	private final HttpStatus httpStatus;

--- a/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
@@ -41,6 +41,7 @@ import com.napzak.api.domain.store.dto.response.StoreProfileModifyResponse;
 import com.napzak.api.domain.store.dto.response.StoreReportResponse;
 import com.napzak.api.domain.store.dto.response.StoreWithdrawResponse;
 import com.napzak.api.domain.store.dto.response.TermsDto;
+import com.napzak.api.domain.store.dto.response.TokensReissueResponse;
 import com.napzak.common.auth.annotation.AuthorizedRole;
 import com.napzak.domain.chat.entity.enums.SystemMessageType;
 import com.napzak.domain.chat.vo.ChatMessage;
@@ -70,6 +71,7 @@ import com.napzak.api.domain.store.service.TokenService;
 import com.napzak.common.exception.NapzakException;
 import com.napzak.common.exception.dto.SuccessResponse;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -390,6 +392,30 @@ public class StoreController implements StoreApi {
 			SuccessResponse.of(
 				StoreSuccessCode.STORE_PHOTO_DELETE_SUCCESS
 			));
+	}
+
+	@AuthorizedRole({Role.ADMIN, Role.STORE})
+	@PostMapping("/reissue-tokens")
+	public ResponseEntity<SuccessResponse<TokensReissueResponse>> reissueTokens(
+		HttpServletRequest request,
+		@CurrentMember Long currentStoreId
+	) {
+		String authHeader = request.getHeader("Authorization");
+		String oldRefreshToken = authHeader.substring(7);
+
+		Role storeRole = storeService.findRoleByStoreId(currentStoreId);
+
+		String newRefreshToken = authenticationService.generateRefreshTokenFromOldRefreshToken(oldRefreshToken, storeRole);
+
+		tokenService.deleteRefreshToken(currentStoreId);
+		tokenService.saveRefreshToken(currentStoreId, newRefreshToken);
+
+		String newAccessToken = authenticationService.generateAccessTokenFromRefreshToken(newRefreshToken).accessToken();
+
+		TokensReissueResponse tokensReissueResponse = TokensReissueResponse.of(newAccessToken, newRefreshToken, storeRole);
+
+		return ResponseEntity.ok(
+			SuccessResponse.of(StoreSuccessCode.TOKENS_REISSUE_SUCCESS, tokensReissueResponse));
 	}
 
 	private List<GenreNameDto> genrePreferenceResponseGenerator(List<GenrePreference> genreList) {

--- a/api-server/src/main/java/com/napzak/api/domain/store/dto/response/TokensReissueResponse.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/dto/response/TokensReissueResponse.java
@@ -1,0 +1,17 @@
+package com.napzak.api.domain.store.dto.response;
+
+import com.napzak.common.auth.role.enums.Role;
+
+public record TokensReissueResponse(
+	String accessToken,
+	String refreshToken,
+	Role role
+) {
+	public static TokensReissueResponse of(
+		final String accessToken,
+		final String refreshToken,
+		final Role role
+	) {
+		return new TokensReissueResponse(accessToken, refreshToken, role);
+	}
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #번호

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
명세서 링크 : [토큰 재발행 api](https://www.notion.so/API-20ef54d645db81d485addcdd09db9bde?source=copy_link)

1. 기존 refresh token으로 새로운 refresh token 발급 (기존 refresh token 검증 o, 현재 db 상 role 기준)
2. 기존 refresh token 삭제
3. 새로운 refresh token 저장
4. 새로운 refresh token으로 access token 새로 발행
5. response 만들어 반환

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="1344" height="1188" alt="image" src="https://github.com/user-attachments/assets/36d73089-d581-4f47-89e2-06a0905dd76a" />


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
