### PR TITLE
[feat] #143 - Dockerfile에 JVM 타임존 설정 추가

### DIFF
--- a/Dockerfile-api-dev
+++ b/Dockerfile-api-dev
@@ -16,4 +16,6 @@ COPY api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json /app/f
 # ✅ JAR 파일은 builder에서 복사
 COPY --from=builder /usr/src/app/api-server/build/libs/api-server.jar /app/
 
+ENV TZ=Asia/Seoul
+ENV JAVA_TOOL_OPTIONS="-Duser.timezone=Asia/Seoul"
 ENTRYPOINT ["java", "-jar", "/app/api-server.jar", "--spring.profiles.active=dev"]

--- a/Dockerfile-chat-dev
+++ b/Dockerfile-chat-dev
@@ -16,4 +16,6 @@ COPY chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json /app/
 # ✅ JAR 파일은 builder에서 복사
 COPY --from=builder /usr/src/app/chat-server/build/libs/chat-server.jar /app/
 
+ENV TZ=Asia/Seoul
+ENV JAVA_TOOL_OPTIONS="-Duser.timezone=Asia/Seoul"
 ENTRYPOINT ["java", "-jar", "/app/chat-server.jar", "--spring.profiles.active=dev"]

--- a/api-server/src/main/java/com/napzak/api/NapzakApiApplication.java
+++ b/api-server/src/main/java/com/napzak/api/NapzakApiApplication.java
@@ -1,5 +1,7 @@
 package com.napzak.api;
 
+import java.util.TimeZone;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -9,8 +11,7 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = {
-	"com.napzak",
-	"websocket.pubsub"
+	"com.napzak"
 })
 @EnableFeignClients(basePackages = "com.napzak.common.auth.client")
 @EnableScheduling
@@ -20,7 +21,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class NapzakApiApplication {
 
 	public static void main(String[] args) {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
 		SpringApplication.run(NapzakApiApplication.class, args);
 	}
-
 }

--- a/chat-server/src/main/java/com/napzak/chat/NapzakChatApplication.java
+++ b/chat-server/src/main/java/com/napzak/chat/NapzakChatApplication.java
@@ -1,5 +1,7 @@
 package com.napzak.chat;
 
+import java.util.TimeZone;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -7,8 +9,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = {
-	"com.napzak",
-	"websocket.pubsub"
+	"com.napzak"
 })
 @EnableScheduling
 @EntityScan(basePackages = "com.napzak.domain")
@@ -16,7 +17,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class NapzakChatApplication {
 
 	public static void main(String[] args) {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
 		SpringApplication.run(NapzakChatApplication.class, args);
 	}
-
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #141 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
Asia/Seoul 타임존 기반으로 LocalDateTime.now()가 작동하도록 보장하기 위해
- Dockerfile에 JVM 타임존 설정 추가하여 JVM 외부 실행 환경 (컨테이너) 시간대 고정
- Spring Boot 앱 main() 함수에 JVM 타임존 설정 추가해 JVM 내 로직에서 확실히 타임존 강제 적용
했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
