### PR TITLE
[fix] #144 - 온보딩 과정 withdraw 유저 접근 허용

### DIFF
--- a/api-server/src/main/java/com/napzak/api/domain/genre/controller/GenreController.java
+++ b/api-server/src/main/java/com/napzak/api/domain/genre/controller/GenreController.java
@@ -37,7 +37,7 @@ public class GenreController implements GenreApi {
 	private final GenreLinkFacade genreLinkFacade;
 
 	@Override
-	@AuthorizedRole({Role.ADMIN, Role.ONBOARDING, Role.STORE})
+	@AuthorizedRole({Role.ADMIN, Role.ONBOARDING, Role.STORE, Role.WITHDRAWN})
 	@GetMapping("/onboarding/genres")
 	public ResponseEntity<SuccessResponse<GenreListResponse>> getGenres(
 		@RequestParam(required = false) String cursor,
@@ -56,7 +56,7 @@ public class GenreController implements GenreApi {
 	}
 
 	@Override
-	@AuthorizedRole({Role.ADMIN, Role.ONBOARDING, Role.STORE})
+	@AuthorizedRole({Role.ADMIN, Role.ONBOARDING, Role.STORE, Role.WITHDRAWN})
 	@GetMapping("/onboarding/genres/search")
 	public ResponseEntity<SuccessResponse<GenreListResponse>> searchGenres(
 		@RequestParam String searchWord,

--- a/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
@@ -154,7 +154,7 @@ public class StoreController implements StoreApi {
 		return ResponseEntity.ok(SuccessResponse.of(StoreSuccessCode.ACCESS_TOKEN_REISSUE_SUCCESS, accessTokenGenerateResponse));
 	}
 
-	@AuthorizedRole({Role.ADMIN, Role.STORE})
+	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING, Role.WITHDRAWN})
 	@GetMapping("/store-id")
 	public ResponseEntity<SuccessResponse<StoreIdResponse>> getStoreId(
 		@CurrentMember final Long currentStoreId
@@ -162,7 +162,7 @@ public class StoreController implements StoreApi {
 		return ResponseEntity.ok(SuccessResponse.of(StoreSuccessCode.GET_STORE_ID_SUCCESS, StoreIdResponse.of(currentStoreId)));
 	}
 
-	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING})
+	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING, Role.WITHDRAWN})
 	@PostMapping("/nickname/check")
 	public ResponseEntity<SuccessResponse<Void>> checkNickname(
 		@RequestBody @Valid NicknameRequest request
@@ -171,7 +171,7 @@ public class StoreController implements StoreApi {
 		return ResponseEntity.ok(SuccessResponse.of(StoreSuccessCode.VALID_NICKNAME_SUCCESS));
 	}
 
-	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING})
+	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING, Role.WITHDRAWN})
 	@PostMapping("/nickname/register")
 	public ResponseEntity<SuccessResponse<Void>> registerNickname(
 		@CurrentMember final Long currentStoreId,
@@ -250,7 +250,7 @@ public class StoreController implements StoreApi {
 		return ResponseEntity.ok().body(SuccessResponse.of(StoreSuccessCode.GET_SETTING_LINK_SUCCESS, settingLinkResponse));
 	}
 
-	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING})
+	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING, Role.WITHDRAWN})
 	@GetMapping("/terms")
 	public ResponseEntity<SuccessResponse<OnboardingTermsListResponse>> getOnboardingTerms() {
 		int activeBundleId = storeTermsBundleFacade.findActiveBundleId();
@@ -268,7 +268,7 @@ public class StoreController implements StoreApi {
 			SuccessResponse.of(StoreSuccessCode.GET_ONBOARDING_TERMS_SUCCESS, onboardingTermsListResponse));
 	}
 
-	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING})
+	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING, Role.WITHDRAWN})
 	@PostMapping("/terms/{bundleId}")
 	public ResponseEntity<SuccessResponse<Void>> registerAgreement(
 		@PathVariable("bundleId") int bundleId,
@@ -300,7 +300,7 @@ public class StoreController implements StoreApi {
 		return ResponseEntity.ok().body(SuccessResponse.of(StoreSuccessCode.GET_STORE_INFO_SUCCESS, storeInfoResponse));
 	}
 
-	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING})
+	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING, Role.WITHDRAWN})
 	@PostMapping("genres/register")
 	public ResponseEntity<SuccessResponse<GenreNameListResponse>> register(
 		@CurrentMember final Long currentStoreId,
@@ -395,7 +395,7 @@ public class StoreController implements StoreApi {
 			));
 	}
 
-	@AuthorizedRole({Role.ADMIN, Role.STORE})
+	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.WITHDRAWN})
 	@PostMapping("/reissue-tokens")
 	public ResponseEntity<SuccessResponse<TokensReissueResponse>> reissueTokens(
 		HttpServletRequest request,


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #번호

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
탈퇴 후 같은 아이디로 다시 회원가입을 할 때, 
store의 role이 withdraw인 상태라 접근 허용 role 관련 이슈가 발생하였습니다.

온보딩 과정에 사용되는 api는 withdraw 유저도 접근 가능하도록 수정하였습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
