### PR TITLE
[fix] #152 - AWS SDK for Java v2 마이그레이션 및 메세지 isRead, isProfileNeeded 판단 로직 수정

### DIFF
--- a/api-server/build.gradle
+++ b/api-server/build.gradle
@@ -38,8 +38,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     // AWS
-    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
-    implementation 'io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4'
+    implementation 'software.amazon.awssdk:s3:2.27.3'
+    implementation 'software.amazon.awssdk:s3control:2.27.3'
+    implementation 'software.amazon.awssdk:s3outposts:2.27.3'
 
     // CoolSMS 등 외부 API
     implementation 'net.nurigo:sdk:4.3.0'

--- a/api-server/build.gradle
+++ b/api-server/build.gradle
@@ -38,9 +38,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     // AWS
-    implementation 'software.amazon.awssdk:s3:2.27.3'
-    implementation 'software.amazon.awssdk:s3control:2.27.3'
-    implementation 'software.amazon.awssdk:s3outposts:2.27.3'
+    implementation 'software.amazon.awssdk:s3:2.32.15'
+    implementation 'software.amazon.awssdk:s3control:2.32.15'
+    implementation 'software.amazon.awssdk:s3outposts:2.32.15'
 
     // CoolSMS 등 외부 API
     implementation 'net.nurigo:sdk:4.3.0'

--- a/api-server/src/main/java/com/napzak/api/domain/file/controller/FileController.java
+++ b/api-server/src/main/java/com/napzak/api/domain/file/controller/FileController.java
@@ -9,8 +9,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.napzak.common.auth.annotation.AuthorizedRole;
-import com.napzak.common.auth.role.enums.Role;
 import com.napzak.common.exception.dto.SuccessResponse;
 import com.napzak.api.domain.file.dto.ProductPresignedUrlFindAllResponse;
 import com.napzak.api.domain.file.dto.StorePresignedUrlFindAllResponse;

--- a/api-server/src/main/java/com/napzak/api/domain/file/service/S3ImageCleaner.java
+++ b/api-server/src/main/java/com/napzak/api/domain/file/service/S3ImageCleaner.java
@@ -6,17 +6,18 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import com.amazonaws.SdkClientException;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.AmazonS3Exception;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
-import com.amazonaws.services.s3.model.ListObjectsV2Request;
-import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.napzak.api.domain.file.code.FileErrorCode;
 import com.napzak.common.exception.NapzakException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 
 @Slf4j
 @Component
@@ -26,27 +27,27 @@ public class S3ImageCleaner {
 	@Value("${cloud.s3.bucket}")
 	private String bucket;
 
-	private final AmazonS3 amazonS3;
+	private final S3Client s3Client;
 
 	//주어진 prefix에 해당하는 S3 key 전체 목록을 가져오는 메서드
 	public List<String> listS3Keys(String prefix) {
 		try {
 			List<String> allS3Keys = new ArrayList<>();
-			ListObjectsV2Request request = new ListObjectsV2Request().withBucketName(bucket).withPrefix(prefix);
-			ListObjectsV2Result result;
-
+			String continuationToken = null;
 			do {
-				result = amazonS3.listObjectsV2(request);
-				result.getObjectSummaries().forEach(s -> allS3Keys.add(s.getKey()));
-				request.setContinuationToken(result.getNextContinuationToken());
-			} while (result.isTruncated());
-
+				ListObjectsV2Request.Builder requestBuilder = ListObjectsV2Request.builder()
+					.bucket(bucket)
+					.prefix(prefix);
+				if (continuationToken != null) {
+					requestBuilder.continuationToken(continuationToken);
+				}
+				ListObjectsV2Response result = s3Client.listObjectsV2(requestBuilder.build());
+				result.contents().forEach(s -> allS3Keys.add(s.key()));
+				continuationToken = result.nextContinuationToken();
+			} while (continuationToken != null);
 			return allS3Keys;
-		} catch (AmazonS3Exception e) {
-			throw new NapzakException(FileErrorCode.S3_ACCESS_DENIED);
-		} catch (SdkClientException e) {
-			throw new NapzakException(FileErrorCode.S3_SERVICE_UNAVAILABLE);
 		} catch (Exception e) {
+			log.error("S3 key 조회 실패", e);
 			throw new NapzakException(FileErrorCode.INTERNAL_SERVER_ERROR);
 		}
 	}
@@ -58,12 +59,16 @@ public class S3ImageCleaner {
 		}
 		try {
 			for (int i = 0; i < unusedKeys.size(); i += 1000) {
-				List<DeleteObjectsRequest.KeyVersion> batch = unusedKeys.subList(i,
-						Math.min(i + 1000, unusedKeys.size()))
-					.stream().map(DeleteObjectsRequest.KeyVersion::new).toList();
+				List<ObjectIdentifier> batch = unusedKeys.subList(i, Math.min(i + 1000, unusedKeys.size()))
+					.stream().map(k -> ObjectIdentifier.builder().key(k).build()).toList();
 
-				log.info("batch = {}", batch);
-				amazonS3.deleteObjects(new DeleteObjectsRequest(bucket).withKeys(batch));
+				DeleteObjectsRequest request = DeleteObjectsRequest.builder()
+					.bucket(bucket)
+					.delete(Delete.builder().objects(batch).build())
+					.build();
+
+				DeleteObjectsResponse response = s3Client.deleteObjects(request);
+				log.info("S3 키 삭제 성공: {}건", response.deleted().size());
 			}
 		} catch (Exception e) {
 			log.error("S3 키 삭제 실패", e);

--- a/common-module/build.gradle
+++ b/common-module/build.gradle
@@ -32,9 +32,9 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     // AWS
-    implementation 'software.amazon.awssdk:s3:2.27.3'
-    implementation 'software.amazon.awssdk:s3control:2.27.3'
-    implementation 'software.amazon.awssdk:s3outposts:2.27.3'
+    implementation 'software.amazon.awssdk:s3:2.32.15'
+    implementation 'software.amazon.awssdk:s3control:2.32.15'
+    implementation 'software.amazon.awssdk:s3outposts:2.32.15'
 
     // lombok 명시적으로 추가 (IDE 인식 보장)
     compileOnly 'org.projectlombok:lombok'

--- a/common-module/build.gradle
+++ b/common-module/build.gradle
@@ -31,7 +31,10 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.751'
+    // AWS
+    implementation 'software.amazon.awssdk:s3:2.27.3'
+    implementation 'software.amazon.awssdk:s3control:2.27.3'
+    implementation 'software.amazon.awssdk:s3outposts:2.27.3'
 
     // lombok 명시적으로 추가 (IDE 인식 보장)
     compileOnly 'org.projectlombok:lombok'


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #152 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
## AWS SDK for Java v2 마이그레이션
### 📌 도입 배경
EC2에서 Docker 기반 배포 환경으로 전환하면서 다음과 같은 문제가 발생했습니다:
- 빌드 성공 후 실행 시점에서 런타임 오류 발생
- AmazonS3Client 내부에서 JMX 등록 시도 중 JVM Metrics 수집 실패로 인해 InvocationTargetException, NullPointerException
- 해당 오류는 Java 17 이후의 jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance()에서 발생
- 원인은 AWS SDK v1이 컨테이너 환경의 JMX 설정과 충돌하며, 내부적으로 OperatingSystemMXBean 접근 시도 때문

### ✅ 주요 변경 사항
- AmazonS3 → S3Client 및 S3Presigner (AWS SDK for Java v2)
- S3Config, FileService, S3ImageCleaner 전면 마이그레이션
- 클라이언트 API 요청/응답 스펙은 완전히 동일하게 유지
- application.yml 설정 형식 및 키 이름 변경 없음

### 🔧 작업 목록
- build.gradle 의존성 변경:
```
implementation 'software.amazon.awssdk:s3:2.32.15'
implementation 'software.amazon.awssdk:s3control:2.32.15'
implementation 'software.amazon.awssdk:s3outposts:2.32.15'
```
- S3Config:
   - AmazonS3 → S3Client, S3Presigner 구성 변경
   - Static credentials 적용 방식 v2에 맞게 수정
- FileService:
   - 기존 generatePresignedUrl 로직을 S3Presigner 기반 presign 방식으로 전환
   - 응답 URL 타입 및 매핑 구조 유지하여 클라이언트 변경 불필요
- S3ImageCleaner:
   - listS3Keys, deleteS3Keys 메서드를 S3Client 기반으로 재작성
   - pagination, batch delete 등 v2 API 로직 반영

## 메세지 목록 조회 dto 내 로직 수정
### isRead 판단 로직 수정
- 메시지를 오래된 순으로 순회하면서 `messageId > opponentLastReadId`를 처음 만나는 시점 이후 모든 메시지에 대해 `isRead = false`로 처리
- 플래그 `prevMessagesWereRead`를 도입하여 이 흐름을 명확히 반영
- 상대방이 퇴장한 뒤 재입장하지 않고 메시지를 수신하지 않았을 경우에도 정확히 `읽지 않음` 처리됨

### PRODUCT 메시지 이후 첫 메시지에 isProfileNeeded 설정
- `PRODUCT` 메시지 이후 바로 다음 일반 메시지 1개에만 `isProfileNeeded = true` 적용되도록 개선
- `expectProfileDueToProduct` 플래그 도입하여 한 번만 적용되도록 설정
- DATE 메시지와는 독립적으로 동작

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="713" height="819" alt="image" src="https://github.com/user-attachments/assets/78260d40-d982-4131-bd1c-b32f5b128834" />
- opponentLastReadId = 80인 경우, messageId 80 이후 메시지는 모두 `isRead = false`로 확인
- PRODUCT 메시지 다음 일반 메시지만 `isProfileNeeded = true` 적용됨을 확인

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **리팩터링**
  * AWS S3 관련 기능을 AWS SDK v1에서 v2로 전면 교체하여, 파일 업로드/삭제 및 presigned URL 생성 로직이 최신 SDK를 사용하도록 개선되었습니다.
  * S3 Presigner, S3Client 등 새로운 클라이언트 방식으로 전환되어 성능 및 보안성이 향상되었습니다.

* **버그 수정**
  * 채팅 메시지의 읽음 처리 및 프로필 표시 로직이 개선되어, PRODUCT 메시지 이후 프로필 노출 조건이 보다 정확하게 동작합니다.

* **기타**
  * 불필요한 import 및 의존성이 정리되고, 내부 예외 처리와 로깅이 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->