### PR TITLE
[fix] #154 - Micrometer system metrics disable & FileDescriptorMetrics 주입 제거

### DIFF
--- a/api-server/src/main/java/com/napzak/api/NapzakApiApplication.java
+++ b/api-server/src/main/java/com/napzak/api/NapzakApiApplication.java
@@ -10,9 +10,12 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = {
-	"com.napzak"
-})
+@SpringBootApplication(
+	scanBasePackages = {"com.napzak"},
+	exclude = {
+		org.springframework.boot.actuate.autoconfigure.metrics.SystemMetricsAutoConfiguration.class
+	}
+)
 @EnableFeignClients(basePackages = "com.napzak.common.auth.client")
 @EnableScheduling
 @EntityScan(basePackages = "com.napzak.domain")

--- a/api-server/src/main/java/com/napzak/api/domain/store/service/LoginService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/service/LoginService.java
@@ -16,7 +16,6 @@ import com.napzak.common.auth.client.enums.SocialType;
 import com.napzak.domain.store.vo.Store;
 import com.napzak.common.exception.NapzakException;
 
-import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,7 +30,6 @@ public class LoginService {
 	private final StoreService storeService;
 	private final GoogleSocialService googleSocialService;
 	private final AppleSocialService appleSocialService;
-	private final FileDescriptorMetrics fileDescriptorMetrics;
 
 	@Transactional
 	public LoginSuccessResponse login(

--- a/chat-server/src/main/java/com/napzak/chat/NapzakChatApplication.java
+++ b/chat-server/src/main/java/com/napzak/chat/NapzakChatApplication.java
@@ -8,9 +8,12 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = {
-	"com.napzak"
-})
+@SpringBootApplication(
+	scanBasePackages = {"com.napzak"},
+	exclude = {
+		org.springframework.boot.actuate.autoconfigure.metrics.SystemMetricsAutoConfiguration.class
+	}
+)
 @EnableScheduling
 @EntityScan(basePackages = "com.napzak.domain")
 @EnableJpaRepositories(basePackages = "com.napzak.domain")


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #154 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
### 🛠 변경 내용
- Micrometer의 SystemMetricsAutoConfiguration 제외 처리로 FileDescriptorMetrics, ProcessorMetrics 자동 생성 차단
- LoginService에서 불필요한 FileDescriptorMetrics 주입 제거
- dev 프로파일(application-dev.yml)에서 metrics.system, metrics.processor 명시적 비활성화

### 🐞 원인
- JDK 17 + Alpine + CGroup v2 환경에서 JVM 내부 Metrics API가 null pointer 예외 발생
- Spring Boot 3.3.1 및 micrometer-core 1.13.1 기준, ProcessorMetrics/FileDescriptorMetrics가 JVM 내부 JMX 호출 중 crash

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
