### PR TITLE
[fix] #154 - actuator metrics system 호출로 인한 부트 실패 이슈 해결

### DIFF
--- a/api-server/src/main/java/com/napzak/api/NapzakApiApplication.java
+++ b/api-server/src/main/java/com/napzak/api/NapzakApiApplication.java
@@ -13,7 +13,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication(
 	scanBasePackages = {"com.napzak"},
 	exclude = {
-		org.springframework.boot.actuate.autoconfigure.metrics.SystemMetricsAutoConfiguration.class
+		org.springframework.boot.actuate.autoconfigure.metrics.SystemMetricsAutoConfiguration.class,
+		org.springframework.boot.actuate.autoconfigure.metrics.web.tomcat.TomcatMetricsAutoConfiguration.class
 	}
 )
 @EnableFeignClients(basePackages = "com.napzak.common.auth.client")

--- a/chat-server/src/main/java/com/napzak/chat/NapzakChatApplication.java
+++ b/chat-server/src/main/java/com/napzak/chat/NapzakChatApplication.java
@@ -11,7 +11,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication(
 	scanBasePackages = {"com.napzak"},
 	exclude = {
-		org.springframework.boot.actuate.autoconfigure.metrics.SystemMetricsAutoConfiguration.class
+		org.springframework.boot.actuate.autoconfigure.metrics.SystemMetricsAutoConfiguration.class,
+		org.springframework.boot.actuate.autoconfigure.metrics.web.tomcat.TomcatMetricsAutoConfiguration.class
 	}
 )
 @EnableScheduling


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #154

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
### 📌 Summary
기존 Spring Boot Actuator의 SystemMetricsAutoConfiguration, TomcatMetricsAutoConfiguration을 통해 생성되는 ProcessorMetrics, FileDescriptorMetrics, TomcatMetrics 등에서 JVM CGroup 관련 오류 발생.

- JVM: OpenJDK 17 / Alpine Linux 환경에서 cgroup v2 mount 정보 null
- Micrometer 내부 Metrics.systemMetrics() -> NullPointerException

### ✅ 변경 사항
- NapzakApiApplication / NapzakChatApplication 에서 해당 auto-config 클래스 exclude

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 내장 Tomcat 웹 서버의 일부 메트릭 자동 구성이 제외되어 애플리케이션의 메트릭 수집 동작이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->