### PR TITLE
[fix] #161 - 탈퇴 시 마켓 소개 초기화 및 admin api 권한 검증 추가

### DIFF
--- a/api-server/src/main/java/com/napzak/api/admin/controller/AdminController.java
+++ b/api-server/src/main/java/com/napzak/api/admin/controller/AdminController.java
@@ -1,7 +1,6 @@
 package com.napzak.api.admin.controller;
 
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -9,12 +8,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.napzak.api.admin.AdminChatFacade;
 import com.napzak.api.admin.code.AdminSuccessCode;
 import com.napzak.api.admin.service.AdminService;
 import com.napzak.api.domain.store.StoreChatFacade;
 import com.napzak.api.domain.store.StoreProductFacade;
+import com.napzak.common.auth.annotation.AuthorizedRole;
 import com.napzak.common.auth.annotation.CurrentMember;
+import com.napzak.common.auth.role.enums.Role;
 import com.napzak.common.exception.dto.SuccessResponse;
 import com.napzak.domain.chat.entity.enums.SystemMessageType;
 import com.napzak.domain.chat.vo.ChatMessage;
@@ -30,6 +30,7 @@ public class AdminController {
 	private final StoreChatFacade storeChatFacade;
 	private final StoreProductFacade storeProductFacade;
 
+	@AuthorizedRole({Role.ADMIN})
 	@PatchMapping("/report-approval/{storeId}")
 	public ResponseEntity<SuccessResponse<Void>> reportApproval(
 		@CurrentMember final Long currentStoreId,

--- a/api-server/src/main/java/com/napzak/api/domain/store/service/StoreService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/service/StoreService.java
@@ -113,7 +113,7 @@ public class StoreService {
 	@Transactional
 	public void withdraw(Long storeId, String title, String description, List<ChatMessage> messages) {
 		withdrawSaver.save(storeId, title, description, LocalDateTime.now());
-		storeUpdater.updateRole(storeId, Role.WITHDRAWN);
+		storeUpdater.updateWithdraw(storeId);
 		genrePreferenceRemover.removeGenrePreference(storeId);
 		chatSystemMessageSender.sendSystemMessages(messages);
 	}

--- a/core-domain/src/main/java/com/napzak/domain/store/crud/store/StoreUpdater.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/crud/store/StoreUpdater.java
@@ -47,4 +47,12 @@ public class StoreUpdater {
 		storeEntity.setRole(role);
 		storeRepository.save(storeEntity);
 	}
+
+	@Transactional
+	public void updateWithdraw(final Long storeId) {
+		StoreEntity storeEntity = storeRepository.findById(storeId)
+			.orElseThrow(() -> new NapzakException(StoreErrorCode.STORE_NOT_FOUND));
+		storeEntity.withdraw();
+		storeRepository.save(storeEntity);
+	}
 }

--- a/core-domain/src/main/java/com/napzak/domain/store/entity/StoreEntity.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/entity/StoreEntity.java
@@ -97,6 +97,11 @@ public class StoreEntity {
 		this.role = role;
 	}
 
+	public void withdraw() {
+		this.role = Role.WITHDRAWN;
+		this.description = null;
+	}
+
 	public void setCover(String cover) {
 		this.cover = cover;
 	}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #161 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 탈퇴 시 마켓 소개 초기화하도록 withdraw entity method 생성 후 적용
- admin api를 admin role인 유저만 사용가능하도록 권한 검증 추가

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 신고 승인 기능에 관리자 전용 접근 제어를 적용했습니다. 이제 관리자만 해당 작업을 수행할 수 있으며, 비관리자 계정은 접근이 제한됩니다.
- Bug Fixes
  - 매장 탈퇴 처리 개선: 탈퇴한 매장이 명확히 ‘탈퇴됨’ 상태로 표시되고 소개 문구가 노출되지 않도록 수정했습니다. 화면 표시 일관성과 데이터 정합성이 향상되며, 관련 알림/후속 처리 흐름은 기존과 동일합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->