### PR TITLE
[fix] #168 - 탈퇴 시 social id 삭제

### DIFF
--- a/core-domain/src/main/java/com/napzak/domain/store/entity/StoreEntity.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/entity/StoreEntity.java
@@ -100,6 +100,7 @@ public class StoreEntity {
 	public void withdraw() {
 		this.role = Role.WITHDRAWN;
 		this.description = null;
+		this.socialId = null;
 	}
 
 	public void setCover(String cover) {


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #168

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
탈퇴 시 social id 삭제를 추가하였습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="901" height="67" alt="image" src="https://github.com/user-attachments/assets/c2781293-91f5-44c5-90cc-47e12a3de9f1" />

애플 계정이 3번 store에 연결되어 있음, 탈퇴 시 social id 란 null로 변경됨. 
같은 계정으로 다시 로그인 시도 시 새로운 social id와 함께 4번 store가 생성됨. 

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

