### PR TITLE
[feat] #173 - 신고, 탈퇴 시 채팅메시지 메타데이터 isProductDeleted 반영

### DIFF
--- a/api-server/src/main/java/com/napzak/api/admin/controller/AdminController.java
+++ b/api-server/src/main/java/com/napzak/api/admin/controller/AdminController.java
@@ -38,6 +38,10 @@ public class AdminController {
 	){
 		List<ChatMessage> messages = storeChatFacade.broadcastSystemMessage(reportedStoreId, SystemMessageType.REPORTED);
 		storeProductFacade.updateProductIsVisibleByStoreId(reportedStoreId);
+
+		List<Long> productIds = storeProductFacade.getProductIdsByStoreId(reportedStoreId);
+		storeChatFacade.updateChatMessageProductMetadataIsProductDeletedByProductId(productIds, true);
+
 		adminService.approveReport(reportedStoreId, messages);
 		return ResponseEntity.ok(SuccessResponse.of(AdminSuccessCode.STORE_REPORT_APPROVE_SUCCESS));
 	}

--- a/api-server/src/main/java/com/napzak/api/domain/product/ProductChatFacade.java
+++ b/api-server/src/main/java/com/napzak/api/domain/product/ProductChatFacade.java
@@ -1,5 +1,6 @@
 package com.napzak.api.domain.product;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Component;
@@ -24,7 +25,13 @@ public class ProductChatFacade {
 		return chatParticipantRetriever.findOpponentStoreId(roomId, myStoreId);
 	}
 
-	public void updateChatMessageProductMetadataIsProductDeleted(Long productId, boolean isProductDeleted) {
-		chatMessageUpdater.updateProductMetadataIsProductDeleted(productId, isProductDeleted);
+	public void updateChatMessageProductMetadataIsProductDeletedByProductId(List<Long> productIds, boolean isProductDeleted) {
+		if(productIds != null) {
+			chatMessageUpdater.updateProductMetadataIsProductDeletedByProductId(productIds, isProductDeleted);
+		}
+	}
+
+	public void updateChatMessageProductMetadataIsProductDeletedByProductId(Long productId, boolean isProductDeleted) {
+		updateChatMessageProductMetadataIsProductDeletedByProductId(java.util.List.of(productId), isProductDeleted);
 	}
 }

--- a/api-server/src/main/java/com/napzak/api/domain/product/service/ProductService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/product/service/ProductService.java
@@ -227,7 +227,7 @@ public class ProductService {
 	public void deleteProduct(Long productId) {
 		productInterestFacade.deleteAllByProductId(productId);
 		productUpdater.updateProductIsVisibleByProductId(productId, false);
-		productChatFacade.updateChatMessageProductMetadataIsProductDeleted(productId, true);
+		productChatFacade.updateChatMessageProductMetadataIsProductDeletedByProductId(productId, true);
 	}
 
 	@Transactional

--- a/api-server/src/main/java/com/napzak/api/domain/store/StoreChatFacade.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/StoreChatFacade.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.napzak.domain.chat.crud.chatmessage.ChatMessageSaver;
+import com.napzak.domain.chat.crud.chatmessage.ChatMessageUpdater;
 import com.napzak.domain.chat.crud.chatparticipant.ChatParticipantRetriever;
 import com.napzak.domain.chat.crud.chatparticipant.ChatParticipantUpdater;
 import com.napzak.domain.chat.entity.enums.SystemMessageType;
@@ -20,6 +21,7 @@ public class StoreChatFacade {
 	private final ChatParticipantRetriever chatParticipantRetriever;
 	private final ChatParticipantUpdater chatParticipantUpdater;
 	private final ChatMessageSaver chatMessageSaver;
+	private final ChatMessageUpdater chatMessageUpdater;
 
 	@Transactional(readOnly = true)
 	public List<Long> getChatRoomIds(Long storeId) {
@@ -35,5 +37,10 @@ public class StoreChatFacade {
 	@Transactional
 	public void exitAllRoomsByStoreId(Long storeId) {
 		chatParticipantUpdater.exitAllRoomsByStoreId(storeId);
+	}
+
+	@Transactional
+	public void updateChatMessageProductMetadataIsProductDeletedByProductId(List<Long> productIds, boolean isProductDeleted) {
+		chatMessageUpdater.updateProductMetadataIsProductDeletedByProductId(productIds, isProductDeleted);
 	}
 }

--- a/api-server/src/main/java/com/napzak/api/domain/store/StoreProductFacade.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/StoreProductFacade.java
@@ -1,5 +1,7 @@
 package com.napzak.api.domain.store;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +20,10 @@ public class StoreProductFacade {
 
 	public int getProductCount(Long storeId, TradeType tradeType) {
 		return productRetriever.countProductsByStoreIdAndTradeType(storeId, tradeType);
+	}
+
+	public List<Long> getProductIdsByStoreId(Long storeId) {
+		return productRetriever.findProductIdsByStoreId(storeId);
 	}
 
 	@Transactional

--- a/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
@@ -353,6 +353,9 @@ public class StoreController implements StoreApi {
 		storeService.withdraw(storeId, request.withdrawTitle(), request.withdrawDescription(), messages);
 		storeInterestFacade.deleteInterestByStoreId(storeId);
 		storeProductFacade.updateProductIsVisibleByStoreId(storeId);
+
+		List<Long> productIds = storeProductFacade.getProductIdsByStoreId(storeId);
+		storeChatFacade.updateChatMessageProductMetadataIsProductDeletedByProductId(productIds, true);
 		storeChatFacade.exitAllRoomsByStoreId(storeId);
 
 		StoreWithdrawResponse response = StoreWithdrawResponse.of(

--- a/core-domain/src/main/java/com/napzak/domain/chat/crud/chatmessage/ChatMessageUpdater.java
+++ b/core-domain/src/main/java/com/napzak/domain/chat/crud/chatmessage/ChatMessageUpdater.java
@@ -1,9 +1,12 @@
 package com.napzak.domain.chat.crud.chatmessage;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
 import com.napzak.domain.chat.repository.ChatMessageRepository;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -14,7 +17,8 @@ public class ChatMessageUpdater {
 
 	private final ChatMessageRepository chatMessageRepository;
 
-	public void updateProductMetadataIsProductDeleted(Long productId, boolean isProductDeleted) {
-		chatMessageRepository.updateProductMetadataIsProductDeleted(productId, isProductDeleted);
+	@Transactional
+	public void updateProductMetadataIsProductDeletedByProductId(List<Long> productIds, boolean isProductDeleted) {
+		chatMessageRepository.updateProductMetadataIsProductDeletedByProductId(productIds, isProductDeleted);
 	}
 }

--- a/core-domain/src/main/java/com/napzak/domain/chat/repository/ChatMessageRepository.java
+++ b/core-domain/src/main/java/com/napzak/domain/chat/repository/ChatMessageRepository.java
@@ -56,7 +56,7 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, 
 			SET metadata = JSON_SET(
 				COALESCE(metadata, JSON_OBJECT()),
 				'$.isProductDeleted', 
-				CAST(:isProductDeleted AS JSON)
+				IF(:isProductDeleted, CAST('true' AS JSON), CAST('false' AS JSON))
 		   )
 			WHERE type = 'PRODUCT'
 				AND CAST(

--- a/core-domain/src/main/java/com/napzak/domain/chat/repository/ChatMessageRepository.java
+++ b/core-domain/src/main/java/com/napzak/domain/chat/repository/ChatMessageRepository.java
@@ -1,5 +1,6 @@
 package com.napzak.domain.chat.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -52,14 +53,21 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, 
 	@Query(
 		value = """
 			UPDATE chat_message
-			SET metadata = JSON_SET(metadata, '$.isProductDeleted', CAST(:isProductDeleted AS JSON))
-			WHERE JSON_EXTRACT(metadata, '$.productId') = CAST(:productId AS JSON)
-				AND type = 'PRODUCT'
+			SET metadata = JSON_SET(
+				COALESCE(metadata, JSON_OBJECT()),
+				'$.isProductDeleted', 
+				CAST(:isProductDeleted AS JSON)
+		   )
+			WHERE type = 'PRODUCT'
+				AND CAST(
+						JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.productId')) 
+						AS UNSIGNED
+						) IN (:productIds)
 		""",
 		nativeQuery = true
 	)
-	void updateProductMetadataIsProductDeleted(
-		@Param("productId") Long productId,
+	void updateProductMetadataIsProductDeletedByProductId(
+		@Param("productIds") List<Long> productIds,
 		@Param("isProductDeleted") boolean isProductDeleted
 	);
 }

--- a/core-domain/src/main/java/com/napzak/domain/product/crud/product/ProductRetriever.java
+++ b/core-domain/src/main/java/com/napzak/domain/product/crud/product/ProductRetriever.java
@@ -120,6 +120,13 @@ public class ProductRetriever {
 		return productRepository.countProductsByFilters(isOnSale, isUnopened, genreIds, tradeType);
 	}
 
+	public List<Long> findProductIdsByStoreId(Long storeId) {
+		List<Long> productIds = productRepository.findProductIdsByStoreId(storeId);
+		List<Long> defaultList = List.of(0L);
+		if (productIds.isEmpty()) { return defaultList; }
+		return productIds;
+	}
+
 	@Transactional(readOnly = true)
 	public List<Product> retrieveRecommendedProducts(Long storeId, List<Long> preferredGenres) {
 		// 추천 상품 조회 흐름:

--- a/core-domain/src/main/java/com/napzak/domain/product/repository/ProductRepository.java
+++ b/core-domain/src/main/java/com/napzak/domain/product/repository/ProductRepository.java
@@ -75,5 +75,8 @@ public interface ProductRepository extends JpaRepository<ProductEntity, Long>, P
 	Optional<ProductEntity> findByIdIncludingInvisible(@Param("productId") Long productId);
 
 	int countByStoreIdAndTradeTypeAndIsVisibleTrue(Long storeId, TradeType tradeType);
+
+	@Query("SELECT p.id FROM ProductEntity p where p.storeId = :storeId")
+	List<Long> findProductIdsByStoreId(@Param("storeId") Long storeId);
 }
 


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #173

## Work Description ✏️

신고, 탈퇴 이슈 발생 시 storeId로 productIds 조회하고,
productIds list에 속해있는 product에 연관된 채팅 metadata에 
isProductDeleted를 반영합니다. 


<img width="580" height="248" alt="image" src="https://github.com/user-attachments/assets/bf08354b-7666-4ace-9bbb-36d2477a4998" />

<!-- 작업 내용을 간단히 소개주세요 -->

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 스토어 탈퇴 및 신고 승인 시 해당 스토어의 모든 상품이 채팅에서 삭제된 것으로 일관되게 표시되도록 수정했습니다.
  * 상품 삭제 후 채팅에 남아 있던 연결 정보가 더 이상 보이지 않도록 해결했습니다.

* **Refactor**
  * 다수 상품을 한꺼번에 처리하는 채팅 메타데이터 업데이트로 성능과 안정성을 개선했습니다.
  * 스토어 관련 흐름(가시성 업데이트·채팅 알림·승인 처리) 간 일관성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->