### PR TITLE
[fix] #203 - LocalDateTime 설정으로 500 리턴 제한

### DIFF
--- a/core-domain/src/main/java/com/napzak/domain/chat/crud/chatmessage/ChatMessageRetriever.java
+++ b/core-domain/src/main/java/com/napzak/domain/chat/crud/chatmessage/ChatMessageRetriever.java
@@ -48,18 +48,13 @@ public class ChatMessageRetriever {
 
 	@Transactional(readOnly = true)
 	public Map<Long, ChatMessage> findLastMessagesByRoomIds(List<Long> roomIds) {
-		Map<Long, ChatMessage> lastMessages = chatMessageRepositoryCustom.findLastMessagesByRoomIds(roomIds)
+
+		return chatMessageRepositoryCustom.findLastMessagesByRoomIds(roomIds)
 			.entrySet().stream()
 			.collect(Collectors.toMap(
 				Map.Entry::getKey,
 				e -> ChatMessage.fromEntity(e.getValue())
 			));
-
-		// for (Long roomId : roomIds) {
-		// 	lastMessages.putIfAbsent(roomId, ChatMessage.empty(roomId));
-		// }
-
-		return lastMessages;
 
 	}
 

--- a/core-domain/src/main/java/com/napzak/domain/chat/vo/ChatMessage.java
+++ b/core-domain/src/main/java/com/napzak/domain/chat/vo/ChatMessage.java
@@ -58,15 +58,4 @@ public class ChatMessage {
 		);
 	}
 
-	// public static ChatMessage empty(Long roomId) {
-	// 	return new ChatMessage(
-	// 		null,
-	// 		roomId,
-	// 		null,
-	// 		MessageType.TEXT,
-	// 		"",
-	// 		null,
-	// 		LocalDateTime.now()
-	// 	);
-	// }
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #203

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 채팅방 목록에서 마지막 메시지가 없는 방에 더 이상 임시/빈 메시지가 표시되지 않습니다. 실제 메시지가 있는 방만 마지막 메시지가 노출되어 목록의 정확성이 향상되었습니다.
  - 마지막 메시지 집계 동작을 정교화하여 드물게 나타나던 빈 내용·잘못된 시간 표기가 해소되었고, 관련 화면의 로딩 일관성도 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->