### PR TITLE
[feat] #214 - 채팅 관련 정보 조회 응답 필드 수정 및 금지 닉네임 지정

### DIFF
--- a/api-server/src/main/java/com/napzak/api/domain/store/service/StoreService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/service/StoreService.java
@@ -2,6 +2,7 @@ package com.napzak.api.domain.store.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -52,6 +53,10 @@ public class StoreService {
 	private final StoreBlockRemover storeBlockRemover;
 	private final ChatSystemMessageSender chatSystemMessageSender;
 
+	private static final Set<String> BANNED_NICKNAMES = Set.of(
+		"napzakmarket", "napzak", "납작마켓"
+	);
+
 	@Transactional(readOnly = true)
 	public boolean checkStoreExistsBySocialIdAndSocialType(final String socialId, final SocialType socialType) {
 		return storeRetriever.checkStoreExistsBySocialIdAndSocialType(socialId, socialType);
@@ -84,6 +89,13 @@ public class StoreService {
 
 	@Transactional(readOnly = true)
 	public void validateNickname(String nickname) {
+		String normalized = nickname.toLowerCase();
+		for (String banned : BANNED_NICKNAMES) {
+			if (normalized.equals(banned.toLowerCase())) {
+				throw new NapzakException(StoreErrorCode.DUPLICATE_NICKNAME);
+			}
+		}
+
 		if (storeRetriever.existsByNickname(nickname)) {
 			throw new NapzakException(StoreErrorCode.DUPLICATE_NICKNAME);
 		}

--- a/core-domain/src/main/java/com/napzak/domain/store/crud/storeblock/StoreBlockRetriever.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/crud/storeblock/StoreBlockRetriever.java
@@ -28,8 +28,7 @@ public class StoreBlockRetriever {
 		}
 		boolean isOpponentStoreBlocked  =
 			storeBlockRepository.existsByBlockerStoreIdAndBlockedStoreId(myStoreId, opponentStoreId);
-		boolean isChatBlocked = isOpponentStoreBlocked
-			|| storeBlockRepository.existsByBlockerStoreIdAndBlockedStoreId(opponentStoreId, myStoreId);
+		boolean isChatBlocked = storeBlockRepository.existsByBlockerStoreIdAndBlockedStoreId(opponentStoreId, myStoreId);
 
 		return new BlockStatus(isOpponentStoreBlocked, isChatBlocked);
 	}

--- a/core-domain/src/main/java/com/napzak/domain/store/vo/BlockStatus.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/vo/BlockStatus.java
@@ -1,7 +1,7 @@
 package com.napzak.domain.store.vo;
 
 public record BlockStatus(
-	boolean isOpponentStoreBlocked,
-	boolean isChatBlocked
+	boolean isOpponentStoreBlocked, // 상대방 상점을 차단했는지 여부
+	boolean isChatBlocked // 상대방이 내 상점을 차단했는지 여부
 ) {
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #214 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

- 채팅 관련 정보 조회 응답 필드 수정
  - 클라이언트의 요구에 따라 isChatBlocked를 상대방이 내 상점을 차단했는지 여부의 의미로 바꾸며 판단 로직을 바꾸고, BlockStatus에 설명 주석을 추가했습니다.
- 금지 닉네임 지정
  - 기획 요구사항에 따라 서비스명과 동일해 금칙어로 지정된 닉네임들을 StoreController에서 BANNED_NICKNAMES로 관리하고 닉네임 검증 시 이와 동일 여부를 판단하도록 수정했습니다.
  - 영문의 경우 대소문자 상관없이 동일 여부를 판단하도록 했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="423" height="920" alt="image" src="https://github.com/user-attachments/assets/9c80c7fc-3180-492a-913a-36525639e20b" />

내가 상대방을 차단했지만 상대방은 나를 차단하지 않은 상황에서 정상적으로 
            "isOpponentStoreBlocked": true,
            "isChatBlocked": false
를 반환함을 확인했습니다.

<img width="436" height="415" alt="image" src="https://github.com/user-attachments/assets/7427a9e3-38c7-46f8-a3da-1774f037216e" />

금칙어를 정상적으로 중복닉네임으로 판단합니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
