### PR TITLE
[feat] #251 - 채팅 메시지 조회 admin API 추가 (CS 이슈 재현용)

### DIFF
--- a/chat-server/src/main/java/com/napzak/chat/domain/chat/api/controller/ChatRestController.java
+++ b/chat-server/src/main/java/com/napzak/chat/domain/chat/api/controller/ChatRestController.java
@@ -121,6 +121,29 @@ public class ChatRestController {
 		);
 	}
 
+	@AuthorizedRole({Role.ADMIN})
+	@GetMapping("/{roomId}/messages/admin")
+	public ResponseEntity<SuccessResponse<ChatMessageListResponse>> getMessagesAdmin(
+		@PathVariable Long roomId,
+		@RequestParam(required = false) String cursor,
+		@RequestParam(defaultValue = "100") int size,
+		@RequestParam Long viewerStoreId,
+		@RequestParam String reason
+	) {
+		ChatMessageSortOption sortOption = ChatMessageSortOption.OLDEST;
+		ChatMessagePagination pagination = chatRestService.findChatRoomMessages(
+			roomId, parseCursorValues(cursor, sortOption), size);
+		Long opponentLastReadId = chatRestService.findOpponentLastReadMessageId(roomId, viewerStoreId);
+
+		ChatMessageListResponse response = ChatMessageListResponse.from(
+			pagination, sortOption, viewerStoreId, opponentLastReadId
+		);
+
+		return ResponseEntity.ok(
+			SuccessResponse.of(ChatSuccessCode.MESSAGE_LIST_RETRIEVE_SUCCESS, response)
+		);
+	}
+
 	@AuthorizedRole({Role.ADMIN, Role.STORE})
 	@GetMapping("/{roomId}/messages")
 	public ResponseEntity<SuccessResponse<ChatMessageListResponse>> getMessages(


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #251 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 채팅 메시지 목록을 특정 사용자 시점으로 조회할 수 있는 admin API 추가
- viewerStoreId를 통해 실제 사용자 관점에서 메시지 조회 가능하도록 지원
- 운영 중 발생한 "메시지 목록 조회 불가" CS 이슈 재현 및 원인 분석 목적

## 📌 API 스펙
GET chat/rooms/{roomId}/messages/admin

Query Params
- viewerStoreId (Long): 조회 기준 사용자 storeId
- cursor (optional): pagination cursor
- size (default=100): 조회 개수
- reason (String): 조회 사유 (감사 로그용)

## 🎯 도입 배경
- 일부 사용자에서 채팅 메시지 목록이 조회되지 않는 CS 이슈 발생
- 로컬/개발 환경에서 재현이 어려운 상황
- 실제 사용자 context 기반 조회를 통해 문제 원인 파악 필요

## ⚠️ 주의 사항
admin 권한(Role.ADMIN)에서만 접근 가능

## 📎 기타
- 기존 메시지 조회 로직(findChatRoomMessages) 재사용
- viewer context 기반 완전한 재현이 필요한 경우, 추후 서비스 레벨 리팩토링 고려 예정

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
