### PR TITLE
[feat] #260 - 번호 인증 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,5 +188,12 @@ src/main/resources/application-dev.yml
 src/main/resources/application-prod.yml
 **/application-*.yml
 
+# Gradle build outputs
+build/
+.gradle/
+
+# Firebase credentials
+**/resources/firebase/
+
 ## Ignore Qclass
-src/main/generated/querydsl
+**/src/main/generated/

--- a/api-server/build.gradle
+++ b/api-server/build.gradle
@@ -44,7 +44,6 @@ dependencies {
 
     // CoolSMS 등 외부 API
     implementation 'net.nurigo:sdk:4.3.2'
-    implementation 'net.nurigo:javaSDK:2.2'
 
     // WebClient
     implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/api-server/build.gradle
+++ b/api-server/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation 'software.amazon.awssdk:s3outposts:2.32.15'
 
     // CoolSMS 등 외부 API
-    implementation 'net.nurigo:sdk:4.3.0'
+    implementation 'net.nurigo:sdk:4.3.2'
     implementation 'net.nurigo:javaSDK:2.2'
 
     // WebClient

--- a/api-server/src/main/java/com/napzak/api/domain/store/code/SmsSuccessCode.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/code/SmsSuccessCode.java
@@ -1,0 +1,22 @@
+package com.napzak.api.domain.store.code;
+
+import org.springframework.http.HttpStatus;
+
+import com.napzak.common.exception.base.BaseSuccessCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SmsSuccessCode implements BaseSuccessCode {
+	/*
+	200 Ok
+	 */
+	VERIFICATION_CODE_SEND_SUCCESS(HttpStatus.OK, "인증번호 발송에 성공하였습니다."),
+	;
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+}

--- a/api-server/src/main/java/com/napzak/api/domain/store/code/SmsSuccessCode.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/code/SmsSuccessCode.java
@@ -14,6 +14,7 @@ public enum SmsSuccessCode implements BaseSuccessCode {
 	200 Ok
 	 */
 	VERIFICATION_CODE_SEND_SUCCESS(HttpStatus.OK, "인증번호 발송에 성공하였습니다."),
+	VERIFICATION_CODE_CONFIRM_SUCCESS(HttpStatus.OK, "인증번호 검증 성공 여부가 조회되었습니다.")
 	;
 
 	private final HttpStatus httpStatus;

--- a/api-server/src/main/java/com/napzak/api/domain/store/code/StoreSuccessCode.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/code/StoreSuccessCode.java
@@ -29,6 +29,7 @@ public enum StoreSuccessCode implements BaseSuccessCode {
 	CHANGE_STORE_ROLE_SUCCESS(HttpStatus.OK, "유저 role 변경이 완료되었습니다."),
 	STORE_PHOTO_DELETE_SUCCESS(HttpStatus.OK, "사용하지 않는 S3 유저 이미지가 삭제되었습니다."),
 	STORE_UNBLOCK_SUCCESS(HttpStatus.OK, "유저 차단이 해제되었습니다."),
+	STORE_PHONE_VERIFIED_GET_SUCCESS(HttpStatus.OK, "번호 인증 상태 조회에 성공했습니다."),
 	/*
 	201 Created
 	 */

--- a/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
@@ -486,18 +486,6 @@ public class StoreController implements StoreApi {
 
 	}
 
-	@PostMapping("/reissue/custom")
-	public ResponseEntity<SuccessResponse<AccessTokenGenerateResponse>> reissueAccessTokenCustom(
-		@RequestParam("expireAt") LocalDateTime expireAt,
-		@CookieValue("refreshToken") String refreshToken,
-		@CurrentMember Long currentStoreId
-	) {
-		AccessTokenGenerateResponse response = authenticationService.generateAccessTokenWithCustomExpireAtFromRefreshToken(refreshToken, expireAt);
-
-		return ResponseEntity.ok()
-			.body(SuccessResponse.of(StoreSuccessCode.TOKENS_REISSUE_SUCCESS, response));
-	}
-
 	@PostMapping
 	private List<GenreNameDto> genrePreferenceResponseGenerator(List<GenrePreference> genreList) {
 

--- a/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
@@ -28,7 +28,7 @@ import com.napzak.api.domain.store.StoreTermsBundleFacade;
 import com.napzak.api.domain.store.code.SmsSuccessCode;
 import com.napzak.api.domain.store.dto.request.GenrePreferenceRequest;
 import com.napzak.api.domain.store.dto.request.NicknameRequest;
-import com.napzak.api.domain.store.dto.request.PhoneNumberVerifyRequest;
+import com.napzak.api.domain.store.dto.request.SmsSendRequest;
 import com.napzak.api.domain.store.dto.request.RoleDto;
 import com.napzak.api.domain.store.dto.request.StoreProfileModifyRequest;
 import com.napzak.api.domain.store.dto.request.StoreReportRequest;
@@ -37,7 +37,7 @@ import com.napzak.api.domain.store.dto.response.AccessTokenGenerateResponse;
 import com.napzak.api.domain.store.dto.response.LoginSuccessResponse;
 import com.napzak.api.domain.store.dto.response.MyPageResponse;
 import com.napzak.api.domain.store.dto.response.OnboardingTermsListResponse;
-import com.napzak.api.domain.store.dto.response.PhoneNumberVerifyResponse;
+import com.napzak.api.domain.store.dto.response.SmsSendResponse;
 import com.napzak.api.domain.store.dto.response.SettingLinkResponse;
 import com.napzak.api.domain.store.dto.response.StoreIdResponse;
 import com.napzak.api.domain.store.dto.response.StoreInfoResponse;
@@ -460,11 +460,11 @@ public class StoreController implements StoreApi {
 
 	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING})
 	@PostMapping("/phone-verifications/send")
-	public ResponseEntity<SuccessResponse<PhoneNumberVerifyResponse>> sendVerificationCode(
-		@Valid @RequestBody PhoneNumberVerifyRequest request,
+	public ResponseEntity<SuccessResponse<SmsSendResponse>> sendVerificationCode(
+		@Valid @RequestBody SmsSendRequest request,
 		@CurrentMember Long currentStoreId
 	) {
-		PhoneNumberVerifyResponse response = smsService.sendVerificationCode(request, currentStoreId);
+		SmsSendResponse response = smsService.sendVerificationCode(request, currentStoreId);
 
 		return ResponseEntity.ok()
 			.body(SuccessResponse.of(SmsSuccessCode.VERIFICATION_CODE_SEND_SUCCESS, response));

--- a/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
@@ -458,7 +458,7 @@ public class StoreController implements StoreApi {
 			SuccessResponse.of(StoreSuccessCode.TOKENS_REISSUE_SUCCESS, tokensReissueResponse));
 	}
 
-	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.WITHDRAWN})
+	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING})
 	@PostMapping("/phone-verifications/send")
 	public ResponseEntity<SuccessResponse<PhoneNumberVerifyResponse>> sendVerificationCode(
 		@Valid @RequestBody PhoneNumberVerifyRequest request,
@@ -481,6 +481,8 @@ public class StoreController implements StoreApi {
 		return ResponseEntity.ok()
 			.body(SuccessResponse.of(StoreSuccessCode.TOKENS_REISSUE_SUCCESS, response));
 	}
+
+	@PostMapping
 
 	private List<GenreNameDto> genrePreferenceResponseGenerator(List<GenrePreference> genreList) {
 

--- a/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
@@ -25,8 +25,10 @@ import com.napzak.api.domain.store.StoreInterestFacade;
 import com.napzak.api.domain.store.StoreLinkFacade;
 import com.napzak.api.domain.store.StoreProductFacade;
 import com.napzak.api.domain.store.StoreTermsBundleFacade;
+import com.napzak.api.domain.store.code.SmsSuccessCode;
 import com.napzak.api.domain.store.dto.request.GenrePreferenceRequest;
 import com.napzak.api.domain.store.dto.request.NicknameRequest;
+import com.napzak.api.domain.store.dto.request.PhoneNumberVerifyRequest;
 import com.napzak.api.domain.store.dto.request.RoleDto;
 import com.napzak.api.domain.store.dto.request.StoreProfileModifyRequest;
 import com.napzak.api.domain.store.dto.request.StoreReportRequest;
@@ -35,6 +37,7 @@ import com.napzak.api.domain.store.dto.response.AccessTokenGenerateResponse;
 import com.napzak.api.domain.store.dto.response.LoginSuccessResponse;
 import com.napzak.api.domain.store.dto.response.MyPageResponse;
 import com.napzak.api.domain.store.dto.response.OnboardingTermsListResponse;
+import com.napzak.api.domain.store.dto.response.PhoneNumberVerifyResponse;
 import com.napzak.api.domain.store.dto.response.SettingLinkResponse;
 import com.napzak.api.domain.store.dto.response.StoreIdResponse;
 import com.napzak.api.domain.store.dto.response.StoreInfoResponse;
@@ -43,6 +46,7 @@ import com.napzak.api.domain.store.dto.response.StoreReportResponse;
 import com.napzak.api.domain.store.dto.response.StoreWithdrawResponse;
 import com.napzak.api.domain.store.dto.response.TermsDto;
 import com.napzak.api.domain.store.dto.response.TokensReissueResponse;
+import com.napzak.api.domain.store.service.SmsService;
 import com.napzak.common.auth.annotation.AuthorizedRole;
 import com.napzak.common.auth.jwt.exception.TokenErrorCode;
 import com.napzak.domain.chat.entity.enums.SystemMessageType;
@@ -90,6 +94,7 @@ public class StoreController implements StoreApi {
 	private final StoreService storeService;
 	private final StoreRegistrationService storeRegistrationService;
 	private final AuthenticationService authenticationService;
+	private final SmsService smsService;
 	private final StorePhotoS3ImageCleaner storePhotoS3ImageCleaner;
 	private final StoreGenreFacade storeGenreFacade;
 	private final StoreProductFacade storeProductFacade;
@@ -451,6 +456,18 @@ public class StoreController implements StoreApi {
 
 		return ResponseEntity.ok(
 			SuccessResponse.of(StoreSuccessCode.TOKENS_REISSUE_SUCCESS, tokensReissueResponse));
+	}
+
+	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.WITHDRAWN})
+	@PostMapping("/phone-verifications/send")
+	public ResponseEntity<SuccessResponse<PhoneNumberVerifyResponse>> sendVerificationCode(
+		@Valid @RequestBody PhoneNumberVerifyRequest request,
+		@CurrentMember Long currentStoreId
+	) {
+		PhoneNumberVerifyResponse response = smsService.sendVerificationCode(request, currentStoreId);
+
+		return ResponseEntity.ok()
+			.body(SuccessResponse.of(SmsSuccessCode.VERIFICATION_CODE_SEND_SUCCESS, response));
 	}
 
 	@PostMapping("/reissue/custom")

--- a/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
@@ -1,6 +1,5 @@
 package com.napzak.api.domain.store.controller;
 
-import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -20,17 +19,22 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.napzak.api.domain.genre.dto.response.GenreNameDto;
+import com.napzak.api.domain.genre.dto.response.GenreNameListResponse;
 import com.napzak.api.domain.store.StoreChatFacade;
+import com.napzak.api.domain.store.StoreGenreFacade;
 import com.napzak.api.domain.store.StoreInterestFacade;
 import com.napzak.api.domain.store.StoreLinkFacade;
 import com.napzak.api.domain.store.StoreProductFacade;
 import com.napzak.api.domain.store.StoreTermsBundleFacade;
+import com.napzak.api.domain.store.StoreUseTermsFacade;
 import com.napzak.api.domain.store.code.SmsSuccessCode;
+import com.napzak.api.domain.store.code.StoreSuccessCode;
 import com.napzak.api.domain.store.dto.request.GenrePreferenceRequest;
 import com.napzak.api.domain.store.dto.request.NicknameRequest;
+import com.napzak.api.domain.store.dto.request.RoleDto;
 import com.napzak.api.domain.store.dto.request.SmsConfirmRequest;
 import com.napzak.api.domain.store.dto.request.SmsSendRequest;
-import com.napzak.api.domain.store.dto.request.RoleDto;
 import com.napzak.api.domain.store.dto.request.StoreProfileModifyRequest;
 import com.napzak.api.domain.store.dto.request.StoreReportRequest;
 import com.napzak.api.domain.store.dto.request.StoreWithdrawRequest;
@@ -38,9 +42,9 @@ import com.napzak.api.domain.store.dto.response.AccessTokenGenerateResponse;
 import com.napzak.api.domain.store.dto.response.LoginSuccessResponse;
 import com.napzak.api.domain.store.dto.response.MyPageResponse;
 import com.napzak.api.domain.store.dto.response.OnboardingTermsListResponse;
+import com.napzak.api.domain.store.dto.response.SettingLinkResponse;
 import com.napzak.api.domain.store.dto.response.SmsConfirmResponse;
 import com.napzak.api.domain.store.dto.response.SmsSendResponse;
-import com.napzak.api.domain.store.dto.response.SettingLinkResponse;
 import com.napzak.api.domain.store.dto.response.StoreIdResponse;
 import com.napzak.api.domain.store.dto.response.StoreInfoResponse;
 import com.napzak.api.domain.store.dto.response.StoreProfileModifyResponse;
@@ -48,36 +52,31 @@ import com.napzak.api.domain.store.dto.response.StoreReportResponse;
 import com.napzak.api.domain.store.dto.response.StoreWithdrawResponse;
 import com.napzak.api.domain.store.dto.response.TermsDto;
 import com.napzak.api.domain.store.dto.response.TokensReissueResponse;
+import com.napzak.api.domain.store.service.AuthenticationService;
+import com.napzak.api.domain.store.service.LoginService;
 import com.napzak.api.domain.store.service.SmsService;
+import com.napzak.api.domain.store.service.StorePhotoS3ImageCleaner;
+import com.napzak.api.domain.store.service.StoreRegistrationService;
+import com.napzak.api.domain.store.service.StoreService;
+import com.napzak.api.domain.store.service.TokenService;
 import com.napzak.common.auth.annotation.AuthorizedRole;
+import com.napzak.common.auth.annotation.CurrentMember;
+import com.napzak.common.auth.client.dto.StoreSocialLoginRequest;
 import com.napzak.common.auth.jwt.exception.TokenErrorCode;
+import com.napzak.common.auth.role.enums.Role;
+import com.napzak.common.exception.NapzakException;
+import com.napzak.common.exception.dto.SuccessResponse;
 import com.napzak.domain.chat.entity.enums.SystemMessageType;
 import com.napzak.domain.chat.vo.ChatMessage;
 import com.napzak.domain.external.entity.enums.LinkType;
 import com.napzak.domain.external.entity.enums.TermsType;
 import com.napzak.domain.external.vo.UseTerms;
-import com.napzak.api.domain.genre.dto.response.GenreNameDto;
-import com.napzak.api.domain.genre.dto.response.GenreNameListResponse;
 import com.napzak.domain.genre.code.GenreErrorCode;
 import com.napzak.domain.genre.vo.Genre;
 import com.napzak.domain.product.entity.enums.TradeType;
-import com.napzak.api.domain.store.StoreGenreFacade;
-import com.napzak.api.domain.store.StoreUseTermsFacade;
 import com.napzak.domain.store.code.StoreErrorCode;
-import com.napzak.api.domain.store.code.StoreSuccessCode;
-import com.napzak.api.domain.store.service.AuthenticationService;
-import com.napzak.api.domain.store.service.LoginService;
-import com.napzak.api.domain.store.service.StorePhotoS3ImageCleaner;
-import com.napzak.api.domain.store.service.StoreRegistrationService;
-import com.napzak.api.domain.store.service.StoreService;
-import com.napzak.common.auth.annotation.CurrentMember;
-import com.napzak.common.auth.client.dto.StoreSocialLoginRequest;
-import com.napzak.common.auth.role.enums.Role;
 import com.napzak.domain.store.vo.GenrePreference;
 import com.napzak.domain.store.vo.Store;
-import com.napzak.api.domain.store.service.TokenService;
-import com.napzak.common.exception.NapzakException;
-import com.napzak.common.exception.dto.SuccessResponse;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -486,7 +485,6 @@ public class StoreController implements StoreApi {
 
 	}
 
-	@PostMapping
 	private List<GenreNameDto> genrePreferenceResponseGenerator(List<GenrePreference> genreList) {
 
 		List<Long> genreIds = genreList.stream().map(GenrePreference::getGenreId).toList();

--- a/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
@@ -28,6 +28,7 @@ import com.napzak.api.domain.store.StoreTermsBundleFacade;
 import com.napzak.api.domain.store.code.SmsSuccessCode;
 import com.napzak.api.domain.store.dto.request.GenrePreferenceRequest;
 import com.napzak.api.domain.store.dto.request.NicknameRequest;
+import com.napzak.api.domain.store.dto.request.SmsConfirmRequest;
 import com.napzak.api.domain.store.dto.request.SmsSendRequest;
 import com.napzak.api.domain.store.dto.request.RoleDto;
 import com.napzak.api.domain.store.dto.request.StoreProfileModifyRequest;
@@ -37,6 +38,7 @@ import com.napzak.api.domain.store.dto.response.AccessTokenGenerateResponse;
 import com.napzak.api.domain.store.dto.response.LoginSuccessResponse;
 import com.napzak.api.domain.store.dto.response.MyPageResponse;
 import com.napzak.api.domain.store.dto.response.OnboardingTermsListResponse;
+import com.napzak.api.domain.store.dto.response.SmsConfirmResponse;
 import com.napzak.api.domain.store.dto.response.SmsSendResponse;
 import com.napzak.api.domain.store.dto.response.SettingLinkResponse;
 import com.napzak.api.domain.store.dto.response.StoreIdResponse;
@@ -470,6 +472,20 @@ public class StoreController implements StoreApi {
 			.body(SuccessResponse.of(SmsSuccessCode.VERIFICATION_CODE_SEND_SUCCESS, response));
 	}
 
+
+	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING})
+	@PostMapping("/phone-verifications/confirm")
+	public ResponseEntity<SuccessResponse<SmsConfirmResponse>> confirmVerificationCode(
+		@Valid @RequestBody SmsConfirmRequest request,
+		@CurrentMember Long currentStoreId
+	) {
+		SmsConfirmResponse response = smsService.confirmVerificationCode(request, currentStoreId);
+
+		return ResponseEntity.ok()
+			.body(SuccessResponse.of(SmsSuccessCode.VERIFICATION_CODE_CONFIRM_SUCCESS, response));
+
+	}
+
 	@PostMapping("/reissue/custom")
 	public ResponseEntity<SuccessResponse<AccessTokenGenerateResponse>> reissueAccessTokenCustom(
 		@RequestParam("expireAt") LocalDateTime expireAt,
@@ -483,7 +499,6 @@ public class StoreController implements StoreApi {
 	}
 
 	@PostMapping
-
 	private List<GenreNameDto> genrePreferenceResponseGenerator(List<GenrePreference> genreList) {
 
 		List<Long> genreIds = genreList.stream().map(GenrePreference::getGenreId).toList();

--- a/api-server/src/main/java/com/napzak/api/domain/store/dto/request/PhoneNumberVerifyRequest.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/dto/request/PhoneNumberVerifyRequest.java
@@ -1,0 +1,9 @@
+package com.napzak.api.domain.store.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+
+public record PhoneNumberVerifyRequest(
+	@Pattern(regexp = "^01[016789]\\d{7,8}$", message = "올바른 휴대폰 번호 형식이 아닙니다.")
+	String phoneNumber
+) {
+}

--- a/api-server/src/main/java/com/napzak/api/domain/store/dto/request/PhoneNumberVerifyRequest.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/dto/request/PhoneNumberVerifyRequest.java
@@ -1,9 +1,0 @@
-package com.napzak.api.domain.store.dto.request;
-
-import jakarta.validation.constraints.Pattern;
-
-public record PhoneNumberVerifyRequest(
-	@Pattern(regexp = "^01[016789]\\d{7,8}$", message = "올바른 휴대폰 번호 형식이 아닙니다.")
-	String phoneNumber
-) {
-}

--- a/api-server/src/main/java/com/napzak/api/domain/store/dto/request/SmsConfirmRequest.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/dto/request/SmsConfirmRequest.java
@@ -1,12 +1,13 @@
 package com.napzak.api.domain.store.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record SmsConfirmRequest(
-	@Pattern(regexp = "^01[016789]\\d{7,8}$", message = "올바른 휴대폰 번호 형식이 아닙니다.")
+	@NotBlank @Pattern(regexp = "^01[016789]\\d{7,8}$", message = "올바른 휴대폰 번호 형식이 아닙니다.")
 	String phoneNumber,
 
-	@Pattern(regexp = "^\\d{6}$", message = "올바른 인증 번호 형식이 아닙니다.")
+	@NotBlank @Pattern(regexp = "^\\d{6}$", message = "올바른 인증 번호 형식이 아닙니다.")
 	String code
 ) {
 }

--- a/api-server/src/main/java/com/napzak/api/domain/store/dto/request/SmsConfirmRequest.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/dto/request/SmsConfirmRequest.java
@@ -1,0 +1,12 @@
+package com.napzak.api.domain.store.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+
+public record SmsConfirmRequest(
+	@Pattern(regexp = "^01[016789]\\d{7,8}$", message = "올바른 휴대폰 번호 형식이 아닙니다.")
+	String phoneNumber,
+
+	@Pattern(regexp = "^\\d{6}$", message = "올바른 인증 번호 형식이 아닙니다.")
+	String code
+) {
+}

--- a/api-server/src/main/java/com/napzak/api/domain/store/dto/request/SmsSendRequest.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/dto/request/SmsSendRequest.java
@@ -1,0 +1,9 @@
+package com.napzak.api.domain.store.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+
+public record SmsSendRequest(
+	@Pattern(regexp = "^01[016789]\\d{7,8}$", message = "올바른 휴대폰 번호 형식이 아닙니다.")
+	String phoneNumber
+) {
+}

--- a/api-server/src/main/java/com/napzak/api/domain/store/dto/request/SmsSendRequest.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/dto/request/SmsSendRequest.java
@@ -1,9 +1,10 @@
 package com.napzak.api.domain.store.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record SmsSendRequest(
-	@Pattern(regexp = "^01[016789]\\d{7,8}$", message = "올바른 휴대폰 번호 형식이 아닙니다.")
+	@NotBlank @Pattern(regexp = "^01[016789]\\d{7,8}$", message = "올바른 휴대폰 번호 형식이 아닙니다.")
 	String phoneNumber
 ) {
 }

--- a/api-server/src/main/java/com/napzak/api/domain/store/dto/response/PhoneNumberVerifyResponse.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/dto/response/PhoneNumberVerifyResponse.java
@@ -1,0 +1,6 @@
+package com.napzak.api.domain.store.dto.response;
+
+public record PhoneNumberVerifyResponse(
+	int remainingRequestCount
+) {
+}

--- a/api-server/src/main/java/com/napzak/api/domain/store/dto/response/PhoneNumberVerifyResponse.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/dto/response/PhoneNumberVerifyResponse.java
@@ -1,6 +1,0 @@
-package com.napzak.api.domain.store.dto.response;
-
-public record PhoneNumberVerifyResponse(
-	int remainingRequestCount
-) {
-}

--- a/api-server/src/main/java/com/napzak/api/domain/store/dto/response/SmsConfirmResponse.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/dto/response/SmsConfirmResponse.java
@@ -1,0 +1,6 @@
+package com.napzak.api.domain.store.dto.response;
+
+public record SmsConfirmResponse (
+	boolean isPhoneVerified,
+	int remainingRequestCount
+) {}

--- a/api-server/src/main/java/com/napzak/api/domain/store/dto/response/SmsSendResponse.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/dto/response/SmsSendResponse.java
@@ -1,0 +1,6 @@
+package com.napzak.api.domain.store.dto.response;
+
+public record SmsSendResponse(
+	int remainingRequestCount
+) {
+}

--- a/api-server/src/main/java/com/napzak/api/domain/store/service/AuthenticationService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/service/AuthenticationService.java
@@ -1,6 +1,5 @@
 package com.napzak.api.domain.store.service;
 
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 
@@ -112,21 +111,6 @@ public class AuthenticationService {
 			storeId, role.getRoleName(), authorities);
 
 		return jwtTokenProvider.issueRefreshToken(authenticationToken);
-	}
-
-	@Transactional
-	public AccessTokenGenerateResponse generateAccessTokenWithCustomExpireAtFromRefreshToken(final String refreshToken, LocalDateTime expireAt) {
-
-		validateRefreshToken(refreshToken);
-
-		Long storeId = jwtTokenProvider.getStoreIdFromJwt(refreshToken);
-		verifyStoreIdWithStoredToken(refreshToken, storeId);
-
-		Role role = jwtTokenProvider.getRoleFromJwt(refreshToken);
-		Collection<GrantedAuthority> authorities = List.of(role.toGrantedAuthority());
-
-		UsernamePasswordAuthenticationToken authenticationToken = createAuthenticationToken(storeId, role, authorities);
-		return AccessTokenGenerateResponse.from(jwtTokenProvider.issueAccessTokenWithCustomExpireAt(authenticationToken, expireAt));
 	}
 
 	/**

--- a/api-server/src/main/java/com/napzak/api/domain/store/service/SmsService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/service/SmsService.java
@@ -1,0 +1,95 @@
+package com.napzak.api.domain.store.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+
+import com.napzak.api.domain.store.dto.request.PhoneNumberVerifyRequest;
+import com.napzak.api.domain.store.dto.response.PhoneNumberVerifyResponse;
+import com.napzak.common.exception.NapzakException;
+import com.napzak.common.util.sms.SmsProperties;
+import com.napzak.common.util.sms.SmsUtil;
+import com.napzak.domain.store.code.SmsErrorCode;
+import com.napzak.domain.store.code.StoreErrorCode;
+import com.napzak.domain.store.repository.SmsVerificationRedisRepository;
+import com.napzak.domain.store.repository.StoreRepository;
+import com.napzak.domain.store.entity.StoreEntity;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SmsService {
+
+	private final SmsUtil smsUtil;
+	private final SmsProperties smsProperties;
+
+	private final SmsVerificationRedisRepository smsVerificationRedisRepository;
+	private final StoreRepository storeRepository;
+
+	private final DefaultMessageService messageService;
+
+	public PhoneNumberVerifyResponse sendVerificationCode(PhoneNumberVerifyRequest request, Long storeId) {
+		String phoneNumber = request.phoneNumber();
+
+		// 유효성 검사
+		int remainingCount = validateDailyLimit(phoneNumber);
+		validatePhoneNumberUsage(phoneNumber, storeId);
+		validateFailCount(phoneNumber);
+
+		String authCode = SmsUtil.generateVerificationCode();
+
+		// 로그 출력을 위해 마지막 2개 숫자 제외 전화번호 마스킹
+		String masked = phoneNumber.replaceAll("(\\d{3})-?(\\d{3,4})-?(\\d{2})(\\d{2})", "$1-****-**$4");
+
+		Message message = new Message();
+		message.setFrom(smsProperties.getCoolsms().getSenderNumber());
+		message.setTo(phoneNumber);
+		message.setText(smsUtil.formatMessageText(authCode));
+
+		try {
+			messageService.sendOne(new SingleMessageSendingRequest(message));
+			log.info("[SMS] 인증번호가 발송되었습니다. 발송 대상 번호: {}", masked);
+		} catch (Exception e) {
+			log.error("[SMS] 인증번호 발송이 실패하였습니다. 발송 대상 번호: {}, error: {}", masked, e.getMessage());
+			throw new NapzakException(SmsErrorCode.MESSAGE_SEND_FAILED);
+		}
+
+		// 레디스에 세션 저장 & 업데이트
+		smsVerificationRedisRepository.saveVerificationCode(phoneNumber, authCode);
+		smsVerificationRedisRepository.incrementDailyCount(phoneNumber);
+
+		return new PhoneNumberVerifyResponse(remainingCount - 1);
+	}
+
+	private int validateDailyLimit(String phoneNumber) {
+		int remainingCount = smsProperties.getPolicy().getSendMaxCount() - smsVerificationRedisRepository.getDailyCount(phoneNumber);
+		if (remainingCount == 0) {
+			throw new NapzakException(SmsErrorCode.DAILY_SEND_LIMIT_EXCEEDED);
+		}
+		return remainingCount;
+	}
+
+	private void validatePhoneNumberUsage(String phoneNumber, Long storeId) {
+		Optional<StoreEntity> store = storeRepository.findByPhoneNumber(phoneNumber);
+		if (store.isEmpty()) {
+			return;
+		}
+		if (store.get().getId().equals(storeId)) {
+			throw new NapzakException(StoreErrorCode.ALREADY_VERIFIED);
+		}
+		throw new NapzakException(StoreErrorCode.PHONE_NUMBER_ALREADY_IN_USE);
+	}
+
+	private void validateFailCount(String phoneNumber) {
+		smsVerificationRedisRepository.findVerificationData(phoneNumber)
+			.filter(data -> data.failCount() >= smsProperties.getPolicy().getFailMaxCount())
+			.ifPresent(data -> { throw new NapzakException(SmsErrorCode.VERIFICATION_FAIL_COUNT_EXCEEDED); });
+	}
+}

--- a/api-server/src/main/java/com/napzak/api/domain/store/service/SmsService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/service/SmsService.java
@@ -8,8 +8,8 @@ import net.nurigo.sdk.message.model.Message;
 import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
 import net.nurigo.sdk.message.service.DefaultMessageService;
 
-import com.napzak.api.domain.store.dto.request.PhoneNumberVerifyRequest;
-import com.napzak.api.domain.store.dto.response.PhoneNumberVerifyResponse;
+import com.napzak.api.domain.store.dto.request.SmsSendRequest;
+import com.napzak.api.domain.store.dto.response.SmsSendResponse;
 import com.napzak.common.exception.NapzakException;
 import com.napzak.common.util.sms.SmsProperties;
 import com.napzak.common.util.sms.SmsUtil;
@@ -35,7 +35,7 @@ public class SmsService {
 
 	private final DefaultMessageService messageService;
 
-	public PhoneNumberVerifyResponse sendVerificationCode(PhoneNumberVerifyRequest request, Long storeId) {
+	public SmsSendResponse sendVerificationCode(SmsSendRequest request, Long storeId) {
 		String phoneNumber = request.phoneNumber();
 
 		// 유효성 검사
@@ -65,7 +65,7 @@ public class SmsService {
 		smsVerificationRedisRepository.saveVerificationCode(phoneNumber, authCode);
 		smsVerificationRedisRepository.incrementDailyCount(phoneNumber);
 
-		return new PhoneNumberVerifyResponse(remainingCount - 1);
+		return new SmsSendResponse(remainingCount - 1);
 	}
 
 	private int validateDailyLimit(String phoneNumber) {

--- a/api-server/src/main/java/com/napzak/api/domain/store/service/SmsService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/service/SmsService.java
@@ -24,7 +24,6 @@ import com.napzak.domain.store.repository.SmsVerificationRedisRepository;
 import com.napzak.domain.store.repository.StoreRepository;
 import com.napzak.domain.store.vo.SmsVerificationData;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -61,6 +60,10 @@ public class SmsService {
 		message.setTo(phoneNumber);
 		message.setText(smsUtil.formatMessageText(authCode));
 
+		// 레디스에 세션 저장 & 업데이트
+		smsVerificationRedisRepository.saveVerificationCode(phoneNumber, authCode);
+		smsVerificationRedisRepository.incrementDailyCount(phoneNumber);
+
 		try {
 			messageService.sendOne(new SingleMessageSendingRequest(message));
 			log.info("[SMS] 인증번호가 발송되었습니다. 발송 대상 번호: {}", masked);
@@ -69,17 +72,11 @@ public class SmsService {
 			throw new NapzakException(SmsErrorCode.MESSAGE_SEND_FAILED);
 		}
 
-		// 레디스에 세션 저장 & 업데이트
-		smsVerificationRedisRepository.saveVerificationCode(phoneNumber, authCode);
-		smsVerificationRedisRepository.incrementDailyCount(phoneNumber);
-
 		return new SmsSendResponse(remainingCount - 1);
 	}
 
-	public SmsConfirmResponse confirmVerificationCode(@Valid SmsConfirmRequest request, Long storeId) {
+	public SmsConfirmResponse confirmVerificationCode(SmsConfirmRequest request, Long storeId) {
 		String phoneNumber = request.phoneNumber();
-
-		int remainingCount = validateDailyLimit(phoneNumber);
 
 		// 인증번호 요청과 검증 사이에 같은 번호가 가입되었는지 검증
 		validatePhoneNumberUsage(phoneNumber, storeId);
@@ -108,9 +105,13 @@ public class SmsService {
 			}
 
 			boolean isPhoneVerified = storeService.getStore(storeId).isPhoneVerified();
+			int remainingCount = smsProperties.getPolicy().getSendMaxCount() - smsVerificationRedisRepository.getDailyCount(phoneNumber);
 
 			return new SmsConfirmResponse(isPhoneVerified, remainingCount);
+		} catch (NapzakException e) {
+			throw e;
 		} catch (Exception e) {
+			log.error("[SMS] 인증번호 검증 처리 중 오류", e);
 			throw new NapzakException(SmsErrorCode.MESSAGE_CONFIRM_FAILED);
 		}
 	}

--- a/api-server/src/main/java/com/napzak/api/domain/store/service/SmsService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/service/SmsService.java
@@ -83,12 +83,15 @@ public class SmsService {
 
 		// 인증번호 요청과 검증 사이에 같은 번호가 가입되었는지 검증
 		validatePhoneNumberUsage(phoneNumber, storeId);
-		validateFailCount(phoneNumber);
 
 		Optional<SmsVerificationData> verificationData = smsVerificationRedisRepository.findVerificationData(phoneNumber);
 
 		if (verificationData.isEmpty()) {
 			throw new NapzakException(SmsErrorCode.VERIFICATION_CODE_INVALID);
+		}
+
+		if (verificationData.get().failCount() >= smsProperties.getPolicy().getFailMaxCount()) {
+			throw new NapzakException(SmsErrorCode.VERIFICATION_FAIL_COUNT_EXCEEDED);
 		}
 
 		boolean isCodeMatching = request.code().equals(verificationData.get().code());
@@ -130,11 +133,5 @@ public class SmsService {
 			throw new NapzakException(StoreErrorCode.ALREADY_VERIFIED);
 		}
 		throw new NapzakException(StoreErrorCode.PHONE_NUMBER_ALREADY_IN_USE);
-	}
-
-	private void validateFailCount(String phoneNumber) {
-		smsVerificationRedisRepository.findVerificationData(phoneNumber)
-			.filter(data -> data.failCount() >= smsProperties.getPolicy().getFailMaxCount())
-			.ifPresent(data -> { throw new NapzakException(SmsErrorCode.VERIFICATION_FAIL_COUNT_EXCEEDED); });
 	}
 }

--- a/api-server/src/main/java/com/napzak/api/domain/store/service/SmsService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/service/SmsService.java
@@ -8,17 +8,23 @@ import net.nurigo.sdk.message.model.Message;
 import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
 import net.nurigo.sdk.message.service.DefaultMessageService;
 
+import com.napzak.api.domain.store.dto.request.SmsConfirmRequest;
 import com.napzak.api.domain.store.dto.request.SmsSendRequest;
+import com.napzak.api.domain.store.dto.response.SmsConfirmResponse;
 import com.napzak.api.domain.store.dto.response.SmsSendResponse;
 import com.napzak.common.exception.NapzakException;
+import com.napzak.common.util.encryption.PhoneEncryptionUtil;
 import com.napzak.common.util.sms.SmsProperties;
 import com.napzak.common.util.sms.SmsUtil;
 import com.napzak.domain.store.code.SmsErrorCode;
 import com.napzak.domain.store.code.StoreErrorCode;
+import com.napzak.domain.store.crud.store.StoreUpdater;
+import com.napzak.domain.store.entity.StoreEntity;
 import com.napzak.domain.store.repository.SmsVerificationRedisRepository;
 import com.napzak.domain.store.repository.StoreRepository;
-import com.napzak.domain.store.entity.StoreEntity;
+import com.napzak.domain.store.vo.SmsVerificationData;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -29,11 +35,14 @@ public class SmsService {
 
 	private final SmsUtil smsUtil;
 	private final SmsProperties smsProperties;
+	private final PhoneEncryptionUtil phoneEncryptionUtil;
 
 	private final SmsVerificationRedisRepository smsVerificationRedisRepository;
 	private final StoreRepository storeRepository;
 
 	private final DefaultMessageService messageService;
+	private final StoreService storeService;
+	private final StoreUpdater storeUpdater;
 
 	public SmsSendResponse sendVerificationCode(SmsSendRequest request, Long storeId) {
 		String phoneNumber = request.phoneNumber();
@@ -41,7 +50,6 @@ public class SmsService {
 		// 유효성 검사
 		int remainingCount = validateDailyLimit(phoneNumber);
 		validatePhoneNumberUsage(phoneNumber, storeId);
-		validateFailCount(phoneNumber);
 
 		String authCode = SmsUtil.generateVerificationCode();
 
@@ -68,6 +76,42 @@ public class SmsService {
 		return new SmsSendResponse(remainingCount - 1);
 	}
 
+	public SmsConfirmResponse confirmVerificationCode(@Valid SmsConfirmRequest request, Long storeId) {
+		String phoneNumber = request.phoneNumber();
+
+		int remainingCount = validateDailyLimit(phoneNumber);
+
+		// 인증번호 요청과 검증 사이에 같은 번호가 가입되었는지 검증
+		validatePhoneNumberUsage(phoneNumber, storeId);
+		validateFailCount(phoneNumber);
+
+		Optional<SmsVerificationData> verificationData = smsVerificationRedisRepository.findVerificationData(phoneNumber);
+
+		if (verificationData.isEmpty()) {
+			throw new NapzakException(SmsErrorCode.VERIFICATION_CODE_INVALID);
+		}
+
+		boolean isCodeMatching = request.code().equals(verificationData.get().code());
+
+		try {
+			if (isCodeMatching) {
+				storeUpdater.updatePhone(storeId, phoneNumber);
+				smsVerificationRedisRepository.deleteVerificationData(phoneNumber);
+			}
+			else {
+				// failCount를 증가시켜 세션 업데이트
+				SmsVerificationData updated = verificationData.get().incrementFailCount();
+				smsVerificationRedisRepository.updateVerificationData(phoneNumber, updated);
+			}
+
+			boolean isPhoneVerified = storeService.getStore(storeId).isPhoneVerified();
+
+			return new SmsConfirmResponse(isPhoneVerified, remainingCount);
+		} catch (Exception e) {
+			throw new NapzakException(SmsErrorCode.MESSAGE_CONFIRM_FAILED);
+		}
+	}
+
 	private int validateDailyLimit(String phoneNumber) {
 		int remainingCount = smsProperties.getPolicy().getSendMaxCount() - smsVerificationRedisRepository.getDailyCount(phoneNumber);
 		if (remainingCount == 0) {
@@ -77,7 +121,8 @@ public class SmsService {
 	}
 
 	private void validatePhoneNumberUsage(String phoneNumber, Long storeId) {
-		Optional<StoreEntity> store = storeRepository.findByPhoneNumber(phoneNumber);
+		String phoneNumberHash = phoneEncryptionUtil.hash(phoneNumber);
+		Optional<StoreEntity> store = storeRepository.findByPhoneNumberHash(phoneNumberHash);
 		if (store.isEmpty()) {
 			return;
 		}

--- a/api-server/src/main/java/com/napzak/api/domain/store/service/SmsService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/service/SmsService.java
@@ -62,13 +62,16 @@ public class SmsService {
 
 		// 레디스에 세션 저장 & 업데이트
 		smsVerificationRedisRepository.saveVerificationCode(phoneNumber, authCode);
-		smsVerificationRedisRepository.incrementDailyCount(phoneNumber);
 
 		try {
 			messageService.sendOne(new SingleMessageSendingRequest(message));
+			smsVerificationRedisRepository.incrementDailyCount(phoneNumber);
+
 			log.info("[SMS] 인증번호가 발송되었습니다. 발송 대상 번호: {}", masked);
 		} catch (Exception e) {
 			log.error("[SMS] 인증번호 발송이 실패하였습니다. 발송 대상 번호: {}, error: {}", masked, e.getMessage());
+
+			smsVerificationRedisRepository.deleteVerificationData(phoneNumber);
 			throw new NapzakException(SmsErrorCode.MESSAGE_SEND_FAILED);
 		}
 

--- a/api-server/src/main/java/com/napzak/api/domain/store/service/SmsService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/service/SmsService.java
@@ -87,7 +87,7 @@ public class SmsService {
 		Optional<SmsVerificationData> verificationData = smsVerificationRedisRepository.findVerificationData(phoneNumber);
 
 		if (verificationData.isEmpty()) {
-			throw new NapzakException(SmsErrorCode.VERIFICATION_CODE_INVALID);
+			throw new NapzakException(SmsErrorCode.VERIFICATION_SESSION_NOT_FOUND);
 		}
 
 		if (verificationData.get().failCount() >= smsProperties.getPolicy().getFailMaxCount()) {

--- a/api-server/src/main/java/com/napzak/api/domain/store/service/StoreRegistrationService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/service/StoreRegistrationService.java
@@ -34,7 +34,7 @@ public class StoreRegistrationService {
 		SocialType socialType = storeSocialInfoResponse.socialType();
 
 		// TODO: email 수집 반영
-		Store store = storeSaver.save(null, null, null, Role.ONBOARDING, null, socialId, socialType, null, null);
+		Store store = storeSaver.save(null, null, Role.ONBOARDING, null, socialId, socialType, null, null);
 
 		log.info("Store registered with storeId: {}, role: {}", store.getId(), store.getRole());
 

--- a/api-server/src/main/java/com/napzak/api/domain/store/service/StoreService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/service/StoreService.java
@@ -155,7 +155,9 @@ public class StoreService {
 
 	@Transactional
 	public void withdraw(Long storeId, String title, String description, List<ChatMessage> messages) {
-		withdrawSaver.save(storeId, title, description, LocalDateTime.now());
+		Store store = getStore(storeId);
+		String phoneNumber = store.isPhoneVerified() ? store.getPhoneNumber() : null;
+		withdrawSaver.save(storeId, title, description, LocalDateTime.now(), phoneNumber);
 		storeUpdater.updateWithdraw(storeId);
 		genrePreferenceRemover.removeGenrePreference(storeId);
 		chatSystemMessageSender.sendSystemMessages(messages);

--- a/api-server/src/main/java/com/napzak/api/domain/store/service/StoreService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/service/StoreService.java
@@ -156,8 +156,8 @@ public class StoreService {
 	@Transactional
 	public void withdraw(Long storeId, String title, String description, List<ChatMessage> messages) {
 		Store store = getStore(storeId);
-		String phoneNumber = store.isPhoneVerified() ? store.getPhoneNumber() : null;
-		withdrawSaver.save(storeId, title, description, LocalDateTime.now(), phoneNumber);
+		String phoneNumberEnc = store.isPhoneVerified() ? store.getPhoneNumberEnc() : null;
+		withdrawSaver.save(storeId, title, description, LocalDateTime.now(), phoneNumberEnc);
 		storeUpdater.updateWithdraw(storeId);
 		genrePreferenceRemover.removeGenrePreference(storeId);
 		chatSystemMessageSender.sendSystemMessages(messages);

--- a/common-module/build.gradle
+++ b/common-module/build.gradle
@@ -61,7 +61,6 @@ dependencies {
 
     // CoolSMS
     implementation 'net.nurigo:sdk:4.3.2'
-    implementation 'net.nurigo:javaSDK:2.2'
 }
 
 dependencyManagement {

--- a/common-module/build.gradle
+++ b/common-module/build.gradle
@@ -58,6 +58,10 @@ dependencies {
     implementation 'com.google.guava:guava:32.1.2-jre'
 
     runtimeOnly("io.netty:netty-resolver-dns-native-macos:4.1.109.Final:osx-aarch_64")
+
+    // CoolSMS
+    implementation 'net.nurigo:sdk:4.3.2'
+    implementation 'net.nurigo:javaSDK:2.2'
 }
 
 dependencyManagement {

--- a/common-module/src/main/java/com/napzak/common/auth/jwt/provider/JwtTokenProvider.java
+++ b/common-module/src/main/java/com/napzak/common/auth/jwt/provider/JwtTokenProvider.java
@@ -48,11 +48,6 @@ public class JwtTokenProvider {
 		jwtSecret = Base64.getEncoder().encodeToString(jwtSecret.getBytes(StandardCharsets.UTF_8));
 	}
 
-	public String issueAccessTokenWithCustomExpireAt(final Authentication authentication, final LocalDateTime expireAt) {
-		long expireTime = Duration.between(LocalDateTime.now(), expireAt).toMillis();
-		return issueToken(authentication, expireTime);
-	}
-
 	public String issueAccessToken(final Authentication authentication) {
 		return issueToken(authentication, accessTokenExpireTime);
 	}

--- a/common-module/src/main/java/com/napzak/common/config/SmsConfig.java
+++ b/common-module/src/main/java/com/napzak/common/config/SmsConfig.java
@@ -1,0 +1,25 @@
+package com.napzak.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import net.nurigo.sdk.message.service.DefaultMessageService;
+
+import com.napzak.common.util.sms.SmsProperties;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Configuration
+public class SmsConfig {
+
+	private final SmsProperties smsProperties;
+
+	@Bean
+	public DefaultMessageService messageService() {
+
+		String apiKey = smsProperties.getCoolsms().getApiKey();
+		String apiSecret = smsProperties.getCoolsms().getApiSecret();
+		return new DefaultMessageService(apiKey, apiSecret, "https://api.coolsms.co.kr");
+	}
+}

--- a/common-module/src/main/java/com/napzak/common/config/SmsConfig.java
+++ b/common-module/src/main/java/com/napzak/common/config/SmsConfig.java
@@ -3,6 +3,7 @@ package com.napzak.common.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import net.nurigo.sdk.NurigoApp;
 import net.nurigo.sdk.message.service.DefaultMessageService;
 
 import com.napzak.common.util.sms.SmsProperties;
@@ -20,6 +21,6 @@ public class SmsConfig {
 
 		String apiKey = smsProperties.getCoolsms().getApiKey();
 		String apiSecret = smsProperties.getCoolsms().getApiSecret();
-		return new DefaultMessageService(apiKey, apiSecret, "https://api.coolsms.co.kr");
+		return NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr");
 	}
 }

--- a/common-module/src/main/java/com/napzak/common/exception/code/ErrorCode.java
+++ b/common-module/src/main/java/com/napzak/common/exception/code/ErrorCode.java
@@ -31,7 +31,10 @@ public enum ErrorCode implements BaseErrorCode {
 	/*
 	 500 INTERNAL SERVER ERROR
 	 */
-	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 오류가 발생했습니다.");
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 오류가 발생했습니다."),
+	ENCRYPTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "암호화 처리 중 오류가 발생했습니다."),
+	DECRYPTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "복호화 처리 중 오류가 발생했습니다."),
+	HASHING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "해시 생성 중 오류가 발생했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/common-module/src/main/java/com/napzak/common/util/encryption/PhoneEncryptionProperties.java
+++ b/common-module/src/main/java/com/napzak/common/util/encryption/PhoneEncryptionProperties.java
@@ -1,0 +1,16 @@
+package com.napzak.common.util.encryption;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "encryption.phone")
+public class PhoneEncryptionProperties {
+	private String aesKey;
+	private String hmacSecret;
+}

--- a/common-module/src/main/java/com/napzak/common/util/encryption/PhoneEncryptionUtil.java
+++ b/common-module/src/main/java/com/napzak/common/util/encryption/PhoneEncryptionUtil.java
@@ -17,6 +17,9 @@ import org.springframework.stereotype.Component;
 import com.napzak.common.exception.NapzakException;
 import com.napzak.common.exception.code.ErrorCode;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Component
 public class PhoneEncryptionUtil {
 
@@ -50,6 +53,7 @@ public class PhoneEncryptionUtil {
 
 			return Base64.getEncoder().encodeToString(combined);
 		} catch (Exception e) {
+			log.error("[SMS] 전화번호 encryption에 실패하였습니다. error: ", e);
 			throw new NapzakException(ErrorCode.ENCRYPTION_FAILED);
 		}
 	}
@@ -65,6 +69,7 @@ public class PhoneEncryptionUtil {
 
 			return new String(cipher.doFinal(encrypted), StandardCharsets.UTF_8);
 		} catch (Exception e) {
+			log.error("[SMS] 전화번호 decryption에 실패하였습니다. error: ", e);
 			throw new NapzakException(ErrorCode.DECRYPTION_FAILED);
 		}
 	}
@@ -76,6 +81,7 @@ public class PhoneEncryptionUtil {
 			byte[] hashBytes = mac.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
 			return HexFormat.of().formatHex(hashBytes);
 		} catch (Exception e) {
+			log.error("[SMS] 전화번호 hasing에 실패하였습니다. error: ", e);
 			throw new NapzakException(ErrorCode.HASHING_FAILED);
 		}
 	}

--- a/common-module/src/main/java/com/napzak/common/util/encryption/PhoneEncryptionUtil.java
+++ b/common-module/src/main/java/com/napzak/common/util/encryption/PhoneEncryptionUtil.java
@@ -1,0 +1,82 @@
+package com.napzak.common.util.encryption;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HexFormat;
+
+import javax.crypto.Cipher;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.stereotype.Component;
+
+import com.napzak.common.exception.NapzakException;
+import com.napzak.common.exception.code.ErrorCode;
+
+@Component
+public class PhoneEncryptionUtil {
+
+	private static final String AES_ALGORITHM = "AES/GCM/NoPadding";
+	private static final String HMAC_ALGORITHM = "HmacSHA256";
+	private static final int IV_LENGTH = 12;
+	private static final int GCM_TAG_LENGTH = 128;
+
+	private final SecretKey aesKey;
+	private final SecretKey hmacKey;
+
+	public PhoneEncryptionUtil(PhoneEncryptionProperties properties) {
+		byte[] aesKeyBytes = Base64.getDecoder().decode(properties.getAesKey());
+		this.aesKey = new SecretKeySpec(aesKeyBytes, "AES");
+		byte[] hmacKeyBytes = Base64.getDecoder().decode(properties.getHmacSecret());
+		this.hmacKey = new SecretKeySpec(hmacKeyBytes, HMAC_ALGORITHM);
+	}
+
+	public String encrypt(String plaintext) {
+		try {
+			byte[] iv = new byte[IV_LENGTH];
+			new SecureRandom().nextBytes(iv);
+
+			Cipher cipher = Cipher.getInstance(AES_ALGORITHM);
+			cipher.init(Cipher.ENCRYPT_MODE, aesKey, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+			byte[] encrypted = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
+
+			byte[] combined = new byte[IV_LENGTH + encrypted.length];
+			System.arraycopy(iv, 0, combined, 0, IV_LENGTH);
+			System.arraycopy(encrypted, 0, combined, IV_LENGTH, encrypted.length);
+
+			return Base64.getEncoder().encodeToString(combined);
+		} catch (Exception e) {
+			throw new NapzakException(ErrorCode.ENCRYPTION_FAILED);
+		}
+	}
+
+	public String decrypt(String ciphertext) {
+		try {
+			byte[] combined = Base64.getDecoder().decode(ciphertext);
+			byte[] iv = Arrays.copyOfRange(combined, 0, IV_LENGTH);
+			byte[] encrypted = Arrays.copyOfRange(combined, IV_LENGTH, combined.length);
+
+			Cipher cipher = Cipher.getInstance(AES_ALGORITHM);
+			cipher.init(Cipher.DECRYPT_MODE, aesKey, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+
+			return new String(cipher.doFinal(encrypted), StandardCharsets.UTF_8);
+		} catch (Exception e) {
+			throw new NapzakException(ErrorCode.DECRYPTION_FAILED);
+		}
+	}
+
+	public String hash(String plaintext) {
+		try {
+			Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+			mac.init(hmacKey);
+			byte[] hashBytes = mac.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
+			return HexFormat.of().formatHex(hashBytes);
+		} catch (Exception e) {
+			throw new NapzakException(ErrorCode.HASHING_FAILED);
+		}
+	}
+}

--- a/common-module/src/main/java/com/napzak/common/util/encryption/PhoneEncryptionUtil.java
+++ b/common-module/src/main/java/com/napzak/common/util/encryption/PhoneEncryptionUtil.java
@@ -81,7 +81,7 @@ public class PhoneEncryptionUtil {
 			byte[] hashBytes = mac.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
 			return HexFormat.of().formatHex(hashBytes);
 		} catch (Exception e) {
-			log.error("[SMS] 전화번호 hasing에 실패하였습니다. error: ", e);
+			log.error("[SMS] 전화번호 hashing에 실패하였습니다. error: ", e);
 			throw new NapzakException(ErrorCode.HASHING_FAILED);
 		}
 	}

--- a/common-module/src/main/java/com/napzak/common/util/sms/SmsProperties.java
+++ b/common-module/src/main/java/com/napzak/common/util/sms/SmsProperties.java
@@ -1,0 +1,34 @@
+package com.napzak.common.util.sms;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "sms")
+public class SmsProperties {
+
+	private Coolsms coolsms = new Coolsms();
+	private Policy policy = new Policy();
+	private String text;
+
+	@Getter
+	@Setter
+	public static class Coolsms {
+		private String apiKey;
+		private String apiSecret;
+		private String senderNumber;
+	}
+
+	@Getter
+	@Setter
+	public static class Policy {
+		private long verifyExpireTime;
+		private int sendMaxCount;
+		private int failMaxCount;
+	}
+}

--- a/common-module/src/main/java/com/napzak/common/util/sms/SmsUtil.java
+++ b/common-module/src/main/java/com/napzak/common/util/sms/SmsUtil.java
@@ -1,0 +1,25 @@
+package com.napzak.common.util.sms;
+
+import java.security.SecureRandom;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SmsUtil {
+
+	private static final SecureRandom secureRandom = new SecureRandom();
+	private final SmsProperties smsProperties;
+
+	public static String generateVerificationCode() {
+		int code = 100000 + secureRandom.nextInt(900000);
+		return String.valueOf(code);
+	}
+
+	public String formatMessageText(String verificationCode) {
+		String baseText = smsProperties.getText();
+		return String.format(baseText, verificationCode);
+	}
+}

--- a/core-domain/src/main/java/com/napzak/domain/store/code/SmsErrorCode.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/code/SmsErrorCode.java
@@ -1,0 +1,33 @@
+package com.napzak.domain.store.code;
+
+import org.springframework.http.HttpStatus;
+
+import com.napzak.common.exception.base.BaseErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SmsErrorCode implements BaseErrorCode {
+
+	/*
+	400 BAD REQUEST
+	 */
+	VERIFICATION_CODE_INVALID(HttpStatus.BAD_REQUEST, "인증번호가 올바르지 않습니다. 다시 확인해주세요."),
+
+	/*
+	429 TOO MANY REQUESTS
+	 */
+	DAILY_SEND_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "오늘 인증번호 요청 가능 횟수를 초과했습니다."),
+	VERIFICATION_FAIL_COUNT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "인증번호를 여러 번 잘못 입력하셨습니다. 인증번호를 재요청해주세요."),
+
+	/*
+	500 INTERNAL SERVER ERROR
+	 */
+	MESSAGE_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인증번호 발송에 실패했습니다. 다시 시도해주세요."),
+	;
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/core-domain/src/main/java/com/napzak/domain/store/code/SmsErrorCode.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/code/SmsErrorCode.java
@@ -14,7 +14,12 @@ public enum SmsErrorCode implements BaseErrorCode {
 	/*
 	400 BAD REQUEST
 	 */
-	VERIFICATION_CODE_INVALID(HttpStatus.BAD_REQUEST, "인증번호가 올바르지 않습니다. 다시 확인해주세요."),
+	VERIFICATION_CODE_INVALID(HttpStatus.BAD_REQUEST, "인증번호가 만료되었거나 존재하지 않습니다. 다시 요청해주세요."),
+
+	/*
+	404 NOT FOUND
+	 */
+	VERIFICATION_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "진행 중인 번호 인증 요청을 찾을 수 없습니다."),
 
 	/*
 	429 TOO MANY REQUESTS
@@ -26,6 +31,7 @@ public enum SmsErrorCode implements BaseErrorCode {
 	500 INTERNAL SERVER ERROR
 	 */
 	MESSAGE_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인증번호 발송에 실패했습니다. 다시 시도해주세요."),
+	MESSAGE_CONFIRM_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인증번호 확인에 실패했습니다. 다시 시도해주세요."),
 	;
 
 	private final HttpStatus httpStatus;

--- a/core-domain/src/main/java/com/napzak/domain/store/code/SmsErrorCode.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/code/SmsErrorCode.java
@@ -12,14 +12,9 @@ import lombok.RequiredArgsConstructor;
 public enum SmsErrorCode implements BaseErrorCode {
 
 	/*
-	400 BAD REQUEST
-	 */
-	VERIFICATION_CODE_INVALID(HttpStatus.BAD_REQUEST, "인증번호가 만료되었거나 존재하지 않습니다. 다시 요청해주세요."),
-
-	/*
 	404 NOT FOUND
 	 */
-	VERIFICATION_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "진행 중인 번호 인증 요청을 찾을 수 없습니다."),
+	VERIFICATION_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "인증번호가 만료되었거나 존재하지 않습니다. 다시 요청해주세요."),
 
 	/*
 	429 TOO MANY REQUESTS

--- a/core-domain/src/main/java/com/napzak/domain/store/code/StoreErrorCode.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/code/StoreErrorCode.java
@@ -37,6 +37,8 @@ public enum StoreErrorCode implements BaseErrorCode {
 	 */
 	DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용중인 이름이에요."),
 	STORE_REPORT_ALREADY_PROCESSED(HttpStatus.CONFLICT, "이미 처리된 신고 게시물입니다."),
+	ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 번호 인증이 완료된 회원입니다."),
+	PHONE_NUMBER_ALREADY_IN_USE(HttpStatus.CONFLICT, "이미 가입된 번호입니다."),
 	;
 
 	private final HttpStatus httpStatus;

--- a/core-domain/src/main/java/com/napzak/domain/store/crud/store/StoreSaver.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/crud/store/StoreSaver.java
@@ -19,7 +19,6 @@ public class StoreSaver {
 	@Transactional
 	public Store save(
 		final String nickname,
-		final String phoneNumber,
 		final String email,
 		final Role role,
 		final String description,
@@ -28,7 +27,7 @@ public class StoreSaver {
 		final String photo,
 		final String cover
 	) {
-		final StoreEntity storeEntity = StoreEntity.create(nickname, phoneNumber, email, role, description, socialId,
+		final StoreEntity storeEntity = StoreEntity.create(nickname, email, role, description, socialId,
 			socialType, photo, cover);
 
 		storeRepository.save(storeEntity);

--- a/core-domain/src/main/java/com/napzak/domain/store/crud/store/StoreUpdater.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/crud/store/StoreUpdater.java
@@ -53,6 +53,7 @@ public class StoreUpdater {
 		StoreEntity storeEntity = storeRepository.findById(storeId)
 			.orElseThrow(() -> new NapzakException(StoreErrorCode.STORE_NOT_FOUND));
 		storeEntity.withdraw();
+		storeEntity.clearPhoneVerification();
 		storeRepository.save(storeEntity);
 	}
 }

--- a/core-domain/src/main/java/com/napzak/domain/store/crud/store/StoreUpdater.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/crud/store/StoreUpdater.java
@@ -3,6 +3,7 @@ package com.napzak.domain.store.crud.store;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.napzak.common.util.encryption.PhoneEncryptionUtil;
 import com.napzak.domain.store.code.StoreErrorCode;
 import com.napzak.domain.store.entity.StoreEntity;
 import com.napzak.domain.store.repository.StoreRepository;
@@ -16,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 public class StoreUpdater {
 
 	private final StoreRepository storeRepository;
+	private final PhoneEncryptionUtil phoneEncryptionUtil;
 
 	@Transactional
 	public void registerNicknameAndSetRoleAndPhoto(final Long storeId, final String nickname,
@@ -54,6 +56,16 @@ public class StoreUpdater {
 			.orElseThrow(() -> new NapzakException(StoreErrorCode.STORE_NOT_FOUND));
 		storeEntity.withdraw();
 		storeEntity.clearPhoneVerification();
+		storeRepository.save(storeEntity);
+	}
+
+	@Transactional
+	public void updatePhone(final Long storeId, final String phoneNumber) {
+		StoreEntity storeEntity = storeRepository.findById(storeId)
+			.orElseThrow(() -> new NapzakException(StoreErrorCode.STORE_NOT_FOUND));
+		String phoneNumberEnc = phoneEncryptionUtil.encrypt(phoneNumber);
+		String phoneNumberHash = phoneEncryptionUtil.hash(phoneNumber);
+		storeEntity.verifyAndUpdatePhone(phoneNumberEnc, phoneNumberHash);
 		storeRepository.save(storeEntity);
 	}
 }

--- a/core-domain/src/main/java/com/napzak/domain/store/crud/withdraw/WithdrawSaver.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/crud/withdraw/WithdrawSaver.java
@@ -19,8 +19,8 @@ public class WithdrawSaver {
 	private final SlackWebhookSender slackWebhookSender;
 
 	@Transactional
-	public void save(Long storeId, String title, String description, LocalDateTime createdAt) {
-		WithdrawEntity entity = WithdrawEntity.create(storeId, title, description, createdAt);
+	public void save(Long storeId, String title, String description, LocalDateTime createdAt, String phoneNumber) {
+		WithdrawEntity entity = WithdrawEntity.create(storeId, title, description, createdAt, phoneNumber);
 		withdrawRepository.save(entity);
 
 		slackWebhookSender.sendWithdraw("""

--- a/core-domain/src/main/java/com/napzak/domain/store/entity/StoreEntity.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/entity/StoreEntity.java
@@ -164,4 +164,10 @@ public class StoreEntity {
 		this.phoneVerified = true;
 		this.verifiedAt = LocalDateTime.now();
 	}
+
+	public void clearPhoneVerification() {
+		this.phoneNumber = null;
+		this.phoneVerified = false;
+		this.verifiedAt = null;
+	}
 }

--- a/core-domain/src/main/java/com/napzak/domain/store/entity/StoreEntity.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/entity/StoreEntity.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Table(
 	name = StoreTableConstants.TABLE_STORE,
 	indexes = {
-		@Index(name = "uk_store_phone_number", columnList = StoreTableConstants.COLUMN_PHONE_NUMBER, unique = true)
+		@Index(name = "uk_store_phone_number_hash", columnList = StoreTableConstants.COLUMN_PHONE_NUMBER_HASH, unique = true)
 	}
 )
 @Entity
@@ -41,8 +41,11 @@ public class StoreEntity {
 	@Column(name = StoreTableConstants.COLUMN_NICKNAME, nullable = true)
 	private String nickname;
 
-	@Column(name = StoreTableConstants.COLUMN_PHONE_NUMBER, nullable = true)
-	private String phoneNumber;
+	@Column(name = StoreTableConstants.COLUMN_PHONE_NUMBER_ENC, nullable = true)
+	private String phoneNumberEnc;
+
+	@Column(name = StoreTableConstants.COLUMN_PHONE_NUMBER_HASH, nullable = true)
+	private String phoneNumberHash;
 
 	@Column(name = StoreTableConstants.COLUMN_PHONE_VERIFIED, nullable = false)
 	private boolean phoneVerified;
@@ -79,7 +82,6 @@ public class StoreEntity {
 	@Builder
 	private StoreEntity(
 		String nickname,
-		String phoneNumber,
 		boolean phoneVerified,
 		LocalDateTime verifiedAt,
 		String email,
@@ -91,7 +93,6 @@ public class StoreEntity {
 		String cover
 	) {
 		this.nickname = nickname;
-		this.phoneNumber = phoneNumber;
 		this.phoneVerified = phoneVerified;
 		this.verifiedAt = verifiedAt;
 		this.email = email;
@@ -105,7 +106,6 @@ public class StoreEntity {
 
 	public static StoreEntity create(
 		final String nickname,
-		final String phoneNumber,
 		final String email,
 		final Role role,
 		final String description,
@@ -116,7 +116,6 @@ public class StoreEntity {
 	) {
 		return StoreEntity.builder()
 			.nickname(nickname)
-			.phoneNumber(phoneNumber)
 			.phoneVerified(false)
 			.verifiedAt(null)
 			.email(email)
@@ -159,14 +158,16 @@ public class StoreEntity {
 		this.email = email;
 	}
 
-	public void verifyAndUpdatePhone(String phoneNumber) {
-		this.phoneNumber = phoneNumber;
+	public void verifyAndUpdatePhone(String phoneNumberEnc, String phoneNumberHash) {
+		this.phoneNumberEnc = phoneNumberEnc;
+		this.phoneNumberHash = phoneNumberHash;
 		this.phoneVerified = true;
 		this.verifiedAt = LocalDateTime.now();
 	}
 
 	public void clearPhoneVerification() {
-		this.phoneNumber = null;
+		this.phoneNumberEnc = null;
+		this.phoneNumberHash = null;
 		this.phoneVerified = false;
 		this.verifiedAt = null;
 	}

--- a/core-domain/src/main/java/com/napzak/domain/store/entity/StoreTableConstants.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/entity/StoreTableConstants.java
@@ -4,7 +4,8 @@ public class StoreTableConstants {
 	public static final String TABLE_STORE = "store";
 	public static final String COLUMN_ID = "id";
 	public static final String COLUMN_NICKNAME = "nickname";
-	public static final String COLUMN_PHONE_NUMBER = "phone_number";
+	public static final String COLUMN_PHONE_NUMBER_ENC = "phone_number_enc";
+	public static final String COLUMN_PHONE_NUMBER_HASH = "phone_number_hash";
 	public static final String COLUMN_DESCRIPTION = "description";
 	public static final String COLUMN_PHOTO = "photo";
 	public static final String COLUMN_COVER = "cover";

--- a/core-domain/src/main/java/com/napzak/domain/store/entity/WithdrawEntity.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/entity/WithdrawEntity.java
@@ -38,25 +38,25 @@ public class WithdrawEntity {
 	@Column(name = COLUMN_CREATED_AT, nullable = false)
 	private LocalDateTime createdAt;
 
-	@Column(name = COLUMN_PHONE_NUMBER, nullable = true)
-	private String phoneNumber;
+	@Column(name = COLUMN_PHONE_NUMBER_ENC, nullable = true)
+	private String phoneNumberEnc;
 
 	@Builder
-	public WithdrawEntity(Long withdrawerId, String title, String description, LocalDateTime createdAt, String phoneNumber) {
+	public WithdrawEntity(Long withdrawerId, String title, String description, LocalDateTime createdAt, String phoneNumberEnc) {
 		this.withdrawerId = withdrawerId;
 		this.title = title;
 		this.description = description;
 		this.createdAt = createdAt;
-		this.phoneNumber = phoneNumber;
+		this.phoneNumberEnc = phoneNumberEnc;
 	}
 
-	public static WithdrawEntity create(Long withdrawerId, String title, String description, LocalDateTime createdAt, String phoneNumber) {
+	public static WithdrawEntity create(Long withdrawerId, String title, String description, LocalDateTime createdAt, String phoneNumberEnc) {
 		return WithdrawEntity.builder()
 			.withdrawerId(withdrawerId)
 			.title(title)
 			.description(description)
 			.createdAt(createdAt)
-			.phoneNumber(phoneNumber)
+			.phoneNumberEnc(phoneNumberEnc)
 			.build();
 	}
 }

--- a/core-domain/src/main/java/com/napzak/domain/store/entity/WithdrawEntity.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/entity/WithdrawEntity.java
@@ -38,20 +38,25 @@ public class WithdrawEntity {
 	@Column(name = COLUMN_CREATED_AT, nullable = false)
 	private LocalDateTime createdAt;
 
+	@Column(name = COLUMN_PHONE_NUMBER, nullable = true)
+	private String phoneNumber;
+
 	@Builder
-	public WithdrawEntity(Long withdrawerId, String title, String description, LocalDateTime createdAt) {
+	public WithdrawEntity(Long withdrawerId, String title, String description, LocalDateTime createdAt, String phoneNumber) {
 		this.withdrawerId = withdrawerId;
 		this.title = title;
 		this.description = description;
 		this.createdAt = createdAt;
+		this.phoneNumber = phoneNumber;
 	}
 
-	public static WithdrawEntity create(Long withdrawerId, String title, String description, LocalDateTime createdAt) {
+	public static WithdrawEntity create(Long withdrawerId, String title, String description, LocalDateTime createdAt, String phoneNumber) {
 		return WithdrawEntity.builder()
 			.withdrawerId(withdrawerId)
 			.title(title)
 			.description(description)
 			.createdAt(createdAt)
+			.phoneNumber(phoneNumber)
 			.build();
 	}
 }

--- a/core-domain/src/main/java/com/napzak/domain/store/entity/WithdrawTableConstants.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/entity/WithdrawTableConstants.java
@@ -7,4 +7,5 @@ public class WithdrawTableConstants {
 	public static final String COLUMN_TITLE = "title";
 	public static final String COLUMN_DESCRIPTION = "description";
 	public static final String COLUMN_CREATED_AT = "created_at";
+	public static final String COLUMN_PHONE_NUMBER = "phone_number";
 }

--- a/core-domain/src/main/java/com/napzak/domain/store/entity/WithdrawTableConstants.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/entity/WithdrawTableConstants.java
@@ -7,5 +7,5 @@ public class WithdrawTableConstants {
 	public static final String COLUMN_TITLE = "title";
 	public static final String COLUMN_DESCRIPTION = "description";
 	public static final String COLUMN_CREATED_AT = "created_at";
-	public static final String COLUMN_PHONE_NUMBER = "phone_number";
+	public static final String COLUMN_PHONE_NUMBER_ENC = "phone_number_enc";
 }

--- a/core-domain/src/main/java/com/napzak/domain/store/repository/SmsVerificationRedisRepository.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/repository/SmsVerificationRedisRepository.java
@@ -10,8 +10,10 @@ import org.springframework.stereotype.Repository;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.napzak.common.exception.NapzakException;
 import com.napzak.common.util.encryption.PhoneEncryptionUtil;
 import com.napzak.common.util.sms.SmsProperties;
+import com.napzak.domain.store.code.SmsErrorCode;
 import com.napzak.domain.store.vo.SmsVerificationData;
 
 import lombok.RequiredArgsConstructor;
@@ -45,7 +47,12 @@ public class SmsVerificationRedisRepository {
 
 	public void updateVerificationData(String phoneNumber, SmsVerificationData data) {
 		String key = VERIFY_KEY_PREFIX + phoneEncryptionUtil.hash(phoneNumber);
-		Long remainTtl = stringRedisTemplate.getExpire(key);
+		long remainTtl = stringRedisTemplate.getExpire(key);
+
+		if (remainTtl <= 0) {
+			throw new NapzakException(SmsErrorCode.VERIFICATION_SESSION_NOT_FOUND);
+		}
+
 		stringRedisTemplate.opsForValue().set(key, serialize(data), Duration.ofSeconds(remainTtl));
 	}
 

--- a/core-domain/src/main/java/com/napzak/domain/store/repository/SmsVerificationRedisRepository.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/repository/SmsVerificationRedisRepository.java
@@ -1,9 +1,8 @@
 package com.napzak.domain.store.repository;
 
 import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -45,7 +44,7 @@ public class SmsVerificationRedisRepository {
 
 	public void updateVerificationData(String phoneNumber, SmsVerificationData data) {
 		String key = VERIFY_KEY_PREFIX + phoneNumber;
-		long remainTtl = stringRedisTemplate.getExpire(key);
+		Long remainTtl = stringRedisTemplate.getExpire(key);
 		stringRedisTemplate.opsForValue().set(key, serialize(data), Duration.ofSeconds(remainTtl));
 	}
 
@@ -55,12 +54,9 @@ public class SmsVerificationRedisRepository {
 
 	public void incrementDailyCount(String phoneNumber) {
 		String key = DAILY_KEY_PREFIX + phoneNumber;
-
-		// 키가 존재하지 않을 때 자동적으로 값 0으로 초기화되어 저장되고 +1
-		Long count = stringRedisTemplate.opsForValue().increment(key);
-		if (count != null && count == 1) {
-			stringRedisTemplate.expire(key, remainingSecondsUntilMidnight());
-		}
+		Duration ttl = remainingSecondsUntilMidnight();
+		stringRedisTemplate.opsForValue().setIfAbsent(key, "0", ttl);
+		stringRedisTemplate.opsForValue().increment(key);
 	}
 
 	public int getDailyCount(String phoneNumber) {
@@ -69,8 +65,9 @@ public class SmsVerificationRedisRepository {
 	}
 
 	private Duration remainingSecondsUntilMidnight() {
-		LocalDateTime now = LocalDateTime.now();
-		LocalDateTime midnight = LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.MIDNIGHT);
+		ZoneId kst = ZoneId.of("Asia/Seoul");
+		ZonedDateTime now = ZonedDateTime.now(kst);
+		ZonedDateTime midnight = now.toLocalDate().plusDays(1).atStartOfDay(kst);
 		return Duration.between(now, midnight);
 	}
 

--- a/core-domain/src/main/java/com/napzak/domain/store/repository/SmsVerificationRedisRepository.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/repository/SmsVerificationRedisRepository.java
@@ -1,0 +1,92 @@
+package com.napzak.domain.store.repository;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.napzak.common.util.sms.SmsProperties;
+import com.napzak.domain.store.vo.SmsVerificationData;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class SmsVerificationRedisRepository {
+
+	private static final String VERIFY_KEY_PREFIX = "sms:verify:";
+	private static final String DAILY_KEY_PREFIX = "sms:daily:";
+
+	private final StringRedisTemplate stringRedisTemplate;
+	private final ObjectMapper objectMapper;
+
+	private final SmsProperties smsProperties;
+
+	public void saveVerificationCode(String phoneNumber, String code) {
+		String key = VERIFY_KEY_PREFIX + phoneNumber;
+		String value = serialize(SmsVerificationData.of(code));
+		stringRedisTemplate.opsForValue().set(key, value, Duration.ofSeconds(smsProperties.getPolicy().getVerifyExpireTime()));
+	}
+
+	public Optional<SmsVerificationData> findVerificationData(String phoneNumber) {
+		String key = VERIFY_KEY_PREFIX + phoneNumber;
+		String value = stringRedisTemplate.opsForValue().get(key);
+		if (value == null) {
+			return Optional.empty();
+		}
+		return Optional.of(deserialize(value));
+	}
+
+	public void updateVerificationData(String phoneNumber, SmsVerificationData data) {
+		String key = VERIFY_KEY_PREFIX + phoneNumber;
+		long remainTtl = stringRedisTemplate.getExpire(key);
+		stringRedisTemplate.opsForValue().set(key, serialize(data), Duration.ofSeconds(remainTtl));
+	}
+
+	public void deleteVerificationData(String phoneNumber) {
+		stringRedisTemplate.delete(VERIFY_KEY_PREFIX + phoneNumber);
+	}
+
+	public void incrementDailyCount(String phoneNumber) {
+		String key = DAILY_KEY_PREFIX + phoneNumber;
+
+		// 키가 존재하지 않을 때 자동적으로 값 0으로 초기화되어 저장되고 +1
+		Long count = stringRedisTemplate.opsForValue().increment(key);
+		if (count != null && count == 1) {
+			stringRedisTemplate.expire(key, remainingSecondsUntilMidnight());
+		}
+	}
+
+	public int getDailyCount(String phoneNumber) {
+		String value = stringRedisTemplate.opsForValue().get(DAILY_KEY_PREFIX + phoneNumber);
+		return value == null ? 0 : Integer.parseInt(value);
+	}
+
+	private Duration remainingSecondsUntilMidnight() {
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime midnight = LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.MIDNIGHT);
+		return Duration.between(now, midnight);
+	}
+
+	private String serialize(SmsVerificationData data) {
+		try {
+			return objectMapper.writeValueAsString(data);
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("SmsVerificationData 직렬화 실패", e);
+		}
+	}
+
+	private SmsVerificationData deserialize(String value) {
+		try {
+			return objectMapper.readValue(value, SmsVerificationData.class);
+		} catch (JsonProcessingException e) {
+			throw new IllegalStateException("SmsVerificationData 역직렬화 실패", e);
+		}
+	}
+}

--- a/core-domain/src/main/java/com/napzak/domain/store/repository/SmsVerificationRedisRepository.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/repository/SmsVerificationRedisRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.napzak.common.util.encryption.PhoneEncryptionUtil;
 import com.napzak.common.util.sms.SmsProperties;
 import com.napzak.domain.store.vo.SmsVerificationData;
 
@@ -24,17 +25,17 @@ public class SmsVerificationRedisRepository {
 
 	private final StringRedisTemplate stringRedisTemplate;
 	private final ObjectMapper objectMapper;
-
+	private final PhoneEncryptionUtil phoneEncryptionUtil;
 	private final SmsProperties smsProperties;
 
 	public void saveVerificationCode(String phoneNumber, String code) {
-		String key = VERIFY_KEY_PREFIX + phoneNumber;
+		String key = VERIFY_KEY_PREFIX + phoneEncryptionUtil.hash(phoneNumber);
 		String value = serialize(SmsVerificationData.of(code));
 		stringRedisTemplate.opsForValue().set(key, value, Duration.ofSeconds(smsProperties.getPolicy().getVerifyExpireTime()));
 	}
 
 	public Optional<SmsVerificationData> findVerificationData(String phoneNumber) {
-		String key = VERIFY_KEY_PREFIX + phoneNumber;
+		String key = VERIFY_KEY_PREFIX + phoneEncryptionUtil.hash(phoneNumber);
 		String value = stringRedisTemplate.opsForValue().get(key);
 		if (value == null) {
 			return Optional.empty();
@@ -43,24 +44,24 @@ public class SmsVerificationRedisRepository {
 	}
 
 	public void updateVerificationData(String phoneNumber, SmsVerificationData data) {
-		String key = VERIFY_KEY_PREFIX + phoneNumber;
+		String key = VERIFY_KEY_PREFIX + phoneEncryptionUtil.hash(phoneNumber);
 		Long remainTtl = stringRedisTemplate.getExpire(key);
 		stringRedisTemplate.opsForValue().set(key, serialize(data), Duration.ofSeconds(remainTtl));
 	}
 
 	public void deleteVerificationData(String phoneNumber) {
-		stringRedisTemplate.delete(VERIFY_KEY_PREFIX + phoneNumber);
+		stringRedisTemplate.delete(VERIFY_KEY_PREFIX + phoneEncryptionUtil.hash(phoneNumber));
 	}
 
 	public void incrementDailyCount(String phoneNumber) {
-		String key = DAILY_KEY_PREFIX + phoneNumber;
+		String key = DAILY_KEY_PREFIX + phoneEncryptionUtil.hash(phoneNumber);
 		Duration ttl = remainingSecondsUntilMidnight();
 		stringRedisTemplate.opsForValue().setIfAbsent(key, "0", ttl);
 		stringRedisTemplate.opsForValue().increment(key);
 	}
 
 	public int getDailyCount(String phoneNumber) {
-		String value = stringRedisTemplate.opsForValue().get(DAILY_KEY_PREFIX + phoneNumber);
+		String value = stringRedisTemplate.opsForValue().get(DAILY_KEY_PREFIX + phoneEncryptionUtil.hash(phoneNumber));
 		return value == null ? 0 : Integer.parseInt(value);
 	}
 

--- a/core-domain/src/main/java/com/napzak/domain/store/repository/StoreRepository.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/repository/StoreRepository.java
@@ -31,5 +31,5 @@ public interface StoreRepository extends JpaRepository<StoreEntity, Long> {
 	@Query("SELECT s.photo FROM StoreEntity s")
 	List<String> findAllPhoto();
 
-	Optional<StoreEntity> findByPhoneNumber(String phoneNumber);
+	Optional<StoreEntity> findByPhoneNumberHash(String phoneNumberHash);
 }

--- a/core-domain/src/main/java/com/napzak/domain/store/repository/StoreRepository.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/repository/StoreRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.napzak.domain.store.vo.StoreStatus;
 import com.napzak.domain.store.entity.StoreEntity;
 import com.napzak.common.auth.role.enums.Role;
 import com.napzak.common.auth.client.enums.SocialType;
@@ -31,4 +30,6 @@ public interface StoreRepository extends JpaRepository<StoreEntity, Long> {
 
 	@Query("SELECT s.photo FROM StoreEntity s")
 	List<String> findAllPhoto();
+
+	Optional<StoreEntity> findByPhoneNumber(String phoneNumber);
 }

--- a/core-domain/src/main/java/com/napzak/domain/store/vo/SmsVerificationData.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/vo/SmsVerificationData.java
@@ -1,0 +1,16 @@
+package com.napzak.domain.store.vo;
+
+public record SmsVerificationData(
+	String code,
+	int failCount
+) {
+
+	public static SmsVerificationData of(String code) {
+		return new SmsVerificationData(code, 0);
+	}
+
+	public SmsVerificationData incrementFailCount() {
+
+		return new SmsVerificationData(this.code, this.failCount + 1);
+	}
+}

--- a/core-domain/src/main/java/com/napzak/domain/store/vo/Store.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/vo/Store.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 public class Store {
 	private final Long id;
 	private final String nickname;
-	private final String phoneNumber;
+	private final String phoneNumberEnc;
 	private final boolean phoneVerified;
 	private final LocalDateTime verifiedAt;
 	private final String email;
@@ -28,7 +28,7 @@ public class Store {
 	public Store(
 		Long id,
 		String nickname,
-		String phoneNumber,
+		String phoneNumberEnc,
 		boolean phoneVerified,
 		LocalDateTime verifiedAt,
 		String email,
@@ -43,7 +43,7 @@ public class Store {
 	) {
 		this.id = id;
 		this.nickname = nickname;
-		this.phoneNumber = phoneNumber;
+		this.phoneNumberEnc = phoneNumberEnc;
 		this.phoneVerified = phoneVerified;
 		this.verifiedAt = verifiedAt;
 		this.email = email;
@@ -61,7 +61,7 @@ public class Store {
 		return new Store(
 			storeEntity.getId(),
 			storeEntity.getNickname(),
-			storeEntity.getPhoneNumber(),
+			storeEntity.getPhoneNumberEnc(),
 			storeEntity.isPhoneVerified(),
 			storeEntity.getVerifiedAt(),
 			storeEntity.getEmail(),

--- a/core-domain/src/main/java/com/napzak/domain/store/vo/Withdraw.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/vo/Withdraw.java
@@ -14,13 +14,15 @@ public class Withdraw {
 	private final String title;
 	private final String description;
 	private final LocalDateTime createdAt;
+	private final String phoneNumber;
 
 	public static Withdraw fromEntity(WithdrawEntity withdrawEntity) {
 		return new Withdraw(
 			withdrawEntity.getId(),
 			withdrawEntity.getTitle(),
 			withdrawEntity.getDescription(),
-			withdrawEntity.getCreatedAt()
+			withdrawEntity.getCreatedAt(),
+			withdrawEntity.getPhoneNumber()
 		);
 	}
 }

--- a/core-domain/src/main/java/com/napzak/domain/store/vo/Withdraw.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/vo/Withdraw.java
@@ -14,7 +14,7 @@ public class Withdraw {
 	private final String title;
 	private final String description;
 	private final LocalDateTime createdAt;
-	private final String phoneNumber;
+	private final String phoneNumberEnc;
 
 	public static Withdraw fromEntity(WithdrawEntity withdrawEntity) {
 		return new Withdraw(
@@ -22,7 +22,7 @@ public class Withdraw {
 			withdrawEntity.getTitle(),
 			withdrawEntity.getDescription(),
 			withdrawEntity.getCreatedAt(),
-			withdrawEntity.getPhoneNumber()
+			withdrawEntity.getPhoneNumberEnc()
 		);
 	}
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #260

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
  - 인증번호 발송 API, 인증번호 검증 API를 구현하였습니다.      
  - 인증번호는 SecurityRandom을 사용해 6자리의 난수를 생성합니다.   
  - 전화번호 형식은 request dto에서 정규식을 사용해 @Pattern으로 검증합니다.                                                                                                                                       
  - 전화번호는 개인정보보호를 위해 AES-256-GCM으로 암호화하여 저장하고, HMAC-SHA256 해시를 별도 컬럼에 저장하여 중복 검사에 활용합니다. (개인정보 보호법상 전화번호는 암호화 저장 의무 대상이더라고용..) 
  
  - 유저가 탈퇴한 이후 같은 번호로 재가입 할 수 있어야 합니다. 따라서 탈퇴 시 withdraw 엔티티에 phone_number(incoded) 필드를 추가하고, 탈퇴한 유저의 store record에서 전화번호 관련 필드는 null로 세팅합니다. => 탈퇴한 유저 재가입 가능, 탈퇴한 유저의 전화번호 확인 가능 
  - 탈퇴 시 인증된 전화번호를 WithdrawEntity에 암호화된 상태로 보존해, CS 등 기타 처리에서 필요할 때 디코더를 통해 원문을 복원할 수 있게 하였습니다.   

  - 일일 전송 제한 횟수, TTL, 문자 메시지 내용, 인증번호 오입력 제한 등 기획 정책에 해당하는 내용은 모두 yml에서 관리하도록 해 운영성을 높이려고 했습니다.

---

- 인증번호 발송 API 플로우
  1. 일일 전송 횟수 초과 여부 검증
  2. 해당 번호가 이미 다른 계정에 등록됐는지 검증 (HMAC 해시로 조회)                                                                                                                                                        
  3. redis 인증 세션을 생성하고, CoolSMS로 6자리 인증번호 발송 시도
  4-1. 발송 성공 시 발송 카운트 증가
  4-2. 발송 실패 시 세션 삭제                                   
  5. Redis에 failCount를 0으로 설정해 code와 함께 인증 세션을 저장하고, 일일 발송 카운트 증가
  6. 성공 시 남은 발송 카운트와 함께 response 제공

- 인증번호 검증 API 플로우
  1. 해당 번호가 이미 다른 계정에 등록됐는지 검증 (`인증 완료 직전 동일 번호가 다른 계정에 등록된 경우` 체킹)
  2. phone Number로 인증 세션 조회, 존재하지 않으면 예외
  3. 인증 세션에 대해 failCount 조회, 일정 수준보다 많이 틀렸으면 예외                                                                                                                                                  
  4-1. 코드가 일치하면 전화번호 데이터를 store 엔티티에 업데이트 후 인증 세션 삭제
  4-2. 코드가 일치하지 않으면 그 세션의 failCount를 증가      
  5. 남은 발송 카운트, 인증 성공 여부와 함께 response 제공
  
## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

### 발송 요청 성공, SMS 수신
<img width="360" height="694" alt="image" src="https://github.com/user-attachments/assets/eaf67972-0cd9-44e3-ad79-700a0775e897" />

### 발송 요청 - 요청가능 횟수 초과
<img width="856" height="432" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/be4ad927-6c73-4301-9b2e-e297d267c4e5" />

### 발송 요청 - 중복 번호 검사
로그인한 유저의 번호로 등록되어 있으면 '이미 가입된 -'. 아니면 '다른 계정중에서 사용중인 -'
<img width="889" height="438" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/3aad9014-7b35-444d-8525-d7937378ec84" />

### 검증 요청 - 인증 세션 미존재(발송요청되지 않았거나, 세션 만료)
사진 상 status가 400인데 404로 수정하였습니다!
<img width="900" height="510" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/bd3f589e-8c8a-47dd-9ad5-4ac9c0225dc4" />

### 검증 요청 - failCount 초과
<img width="903" height="488" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/ef12219a-2f30-45e3-ba21-e28630dfa6e1" />

### 검증 요청 - 검증 성공 
￼<img width="892" height="508" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/36fa78eb-8c70-4633-8ae9-ec1680675d48" />

### 전화번호 db 저장
<img width="852" height="155" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/2d847c2b-6ae9-4465-884c-ab9d66685e31" />

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->
블랙리스트 엔티티 생성과 블랙리스트 번호 제한 로직은 아직 작업 못했숨니다..
또 소셜 로그인 할 때 이메일도 같이 가져와서 저장하는 부분도 아직입니다..ㅠ 시험 직전이라 시간이 너무 없어서 필수 기능만 우선 구현했습니다. 시험공부 바쁜 것 끝나면 바로 따로 이슈 파고 작업하겠습니다!! (이 두 부분은 다음주 수요일 개발완료 예상)
 
## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
노션 명세서의 failure 응답과 모두 align되도록 작업하였습니다! (노션 명세서 failure 응답/종류를 수정한 부분도 있어서, 한 번 확인해주시면 감사하겠습니다.)

노션 명세서와 github secrets에 최신 yml 업데이트 해두었습니다. 

스프린트 끝나면 솔라피 플랫폼에 자동결제 카드 납작마켓 걸로 등록해둘게요!
+ 발신번호 관련은 정해지는 대로 yml에 반영해둘게용!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * SMS 인증 코드 발송 및 확인 기능 추가
  * 휴대폰 번호 인증 상태 조회 기능 추가
  * 일일 발송 제한 및 검증 실패 횟수 제한 기능 추가

* **Security**
  * 휴대폰 번호 저장 방식을 암호화 및 해시 처리로 보안 강화

* **Chores**
  * CoolSMS SDK를 4.3.2 버전으로 업데이트
  * 레거시 토큰 재발급 API 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->