### PR TITLE
[Deploy] #264 - docker-compose-dev api/chat-server restart 정책 제외

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,7 +9,6 @@ services:
       redis: { condition: service_healthy }
       rabbitmq: { condition: service_healthy }
     networks: [napzak-dev-net]
-    restart: always
 
   chat-server:
     image: 203918864903.dkr.ecr.ap-northeast-2.amazonaws.com/napzak-chat-dev:latest
@@ -20,7 +19,6 @@ services:
       redis: { condition: service_healthy }
       rabbitmq: { condition: service_healthy }
     networks: [napzak-dev-net]
-    restart: always
 
   redis:
     container_name: napzak-dev-redis


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #264 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
docker-compose-dev api/chat-server restart 정책 제외
## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 개발 환경 설정에서 API 서버와 채팅 서버의 자동 재시작 정책을 제거했습니다. 이제 컨테이너가 중지되면 수동으로 다시 시작해야 합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->