### PR TITLE
[Feat] #268 - 번호 인증 상태 조회 API 추가 및 스토어 Swagger 문서 보완

### DIFF
--- a/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreApi.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreApi.java
@@ -3,6 +3,7 @@ package com.napzak.api.domain.store.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -13,16 +14,26 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.napzak.api.domain.genre.dto.response.GenreNameListResponse;
 import com.napzak.api.domain.store.dto.request.GenrePreferenceRequest;
 import com.napzak.api.domain.store.dto.request.NicknameRequest;
+import com.napzak.api.domain.store.dto.request.RoleDto;
+import com.napzak.api.domain.store.dto.request.SmsConfirmRequest;
+import com.napzak.api.domain.store.dto.request.SmsSendRequest;
 import com.napzak.api.domain.store.dto.request.StoreProfileModifyRequest;
 import com.napzak.api.domain.store.dto.request.StoreReportRequest;
 import com.napzak.api.domain.store.dto.request.StoreWithdrawRequest;
 import com.napzak.api.domain.store.dto.response.AccessTokenGenerateResponse;
 import com.napzak.api.domain.store.dto.response.LoginSuccessResponse;
 import com.napzak.api.domain.store.dto.response.MyPageResponse;
+import com.napzak.api.domain.store.dto.response.OnboardingTermsListResponse;
+import com.napzak.api.domain.store.dto.response.PhoneVerificationStatusResponse;
+import com.napzak.api.domain.store.dto.response.SettingLinkResponse;
+import com.napzak.api.domain.store.dto.response.SmsConfirmResponse;
+import com.napzak.api.domain.store.dto.response.SmsSendResponse;
+import com.napzak.api.domain.store.dto.response.StoreIdResponse;
 import com.napzak.api.domain.store.dto.response.StoreInfoResponse;
 import com.napzak.api.domain.store.dto.response.StoreProfileModifyResponse;
 import com.napzak.api.domain.store.dto.response.StoreReportResponse;
 import com.napzak.api.domain.store.dto.response.StoreWithdrawResponse;
+import com.napzak.api.domain.store.dto.response.TokensReissueResponse;
 import com.napzak.common.auth.annotation.CurrentMember;
 import com.napzak.common.auth.client.dto.StoreSocialLoginRequest;
 import com.napzak.common.exception.dto.SuccessResponse;
@@ -35,6 +46,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 
@@ -59,6 +71,26 @@ public interface StoreApi {
 		HttpServletResponse httpServletResponse
 	);
 
+	@DisableSwaggerSecurity
+	@Operation(summary = "카카오 액세스 토큰 로그인", description = "카카오 Access Token을 이용한 소셜 로그인 API")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "카카오 로그인 성공",
+			content = @Content(schema = @Schema(implementation = LoginSuccessResponse.class))),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+		@ApiResponse(responseCode = "401", description = "유효하지 않은 카카오 Access Token")
+	})
+	@PostMapping("/login/kakao")
+	ResponseEntity<SuccessResponse<LoginSuccessResponse>> loginWithKakaoAccessToken(
+		@Parameter(description = "카카오 Access Token")
+		@RequestParam("accessToken") String accessToken,
+
+		@io.swagger.v3.oas.annotations.parameters.RequestBody(
+			description = "스토어 소셜 로그인 요청", required = true,
+			content = @Content(schema = @Schema(implementation = StoreSocialLoginRequest.class))
+		)
+		@RequestBody StoreSocialLoginRequest storeSocialLoginRequest
+	);
+
 	@Operation(summary = "로그아웃", description = "스토어 로그아웃 API")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "로그아웃 성공"),
@@ -78,6 +110,18 @@ public interface StoreApi {
 	ResponseEntity<SuccessResponse<AccessTokenGenerateResponse>> reissue(
 		@Parameter(description = "HttpOnly Cookie에 담긴 Refresh Token", hidden = true)
 		@CookieValue("refreshToken") String refreshToken
+	);
+
+	@Operation(summary = "현재 스토어 ID 조회", description = "현재 로그인한 사용자의 스토어 ID를 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "스토어 ID 조회 성공",
+			content = @Content(schema = @Schema(implementation = StoreIdResponse.class))),
+		@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+	})
+	@GetMapping("/store-id")
+	ResponseEntity<SuccessResponse<StoreIdResponse>> getStoreId(
+		@Parameter(hidden = true)
+		@CurrentMember Long currentStoreId
 	);
 
 	@Operation(summary = "닉네임 중복 및 비속어 검증", description = "닉네임의 중복 여부와 비속어 포함 여부를 검증합니다.")
@@ -135,6 +179,41 @@ public interface StoreApi {
 	@GetMapping("/mypage")
 	ResponseEntity<SuccessResponse<MyPageResponse>> getMyPageInfo(@CurrentMember Long currentStoreId);
 
+	@Operation(summary = "마이페이지 설정 링크 조회", description = "공지사항, 이용약관, 개인정보처리방침, 버전 정보 링크를 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "설정 링크 조회 성공",
+			content = @Content(schema = @Schema(implementation = SettingLinkResponse.class))),
+		@ApiResponse(responseCode = "404", description = "링크 또는 약관 정보를 찾을 수 없습니다.")
+	})
+	@GetMapping("/mypage/setting")
+	ResponseEntity<SuccessResponse<SettingLinkResponse>> getSettingLink(
+		@Parameter(hidden = true)
+		@CurrentMember Long currentStoreId
+	);
+
+	@Operation(summary = "온보딩 약관 목록 조회", description = "현재 활성화된 약관 번들의 필수 약관 목록을 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "온보딩 약관 목록 조회 성공",
+			content = @Content(schema = @Schema(implementation = OnboardingTermsListResponse.class))),
+		@ApiResponse(responseCode = "404", description = "활성화된 약관 번들을 찾을 수 없습니다.")
+	})
+	@GetMapping("/terms")
+	ResponseEntity<SuccessResponse<OnboardingTermsListResponse>> getOnboardingTerms();
+
+	@Operation(summary = "약관 동의 등록", description = "현재 로그인한 사용자의 특정 약관 번들 동의를 등록합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "약관 동의 등록 성공"),
+		@ApiResponse(responseCode = "404", description = "약관 번들을 찾을 수 없습니다.")
+	})
+	@PostMapping("/terms/{bundleId}")
+	ResponseEntity<SuccessResponse<Void>> registerAgreement(
+		@Parameter(description = "약관 번들 ID")
+		@PathVariable("bundleId") int bundleId,
+
+		@Parameter(hidden = true)
+		@CurrentMember Long currentStoreId
+	);
+
 	@Operation(summary = "스토어 정보 조회", description = "스토어 ID 기반 스토어 정보 조회 API")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "스토어 정보 조회 성공",
@@ -155,7 +234,7 @@ public interface StoreApi {
 			content = @Content(schema = @Schema(implementation = GenreNameListResponse.class))),
 		@ApiResponse(responseCode = "400", description = "유효하지 않은 장르 요청")
 	})
-	@PostMapping("/register")
+	@PostMapping("/genres/register")
 	ResponseEntity<SuccessResponse<GenreNameListResponse>> register(
 		@CurrentMember Long currentMemberId,
 
@@ -176,7 +255,37 @@ public interface StoreApi {
 		@RequestBody @Valid StoreReportRequest request
 	);
 
-	@Operation(summary = "스토어 탈퇴", description = "스토어 회원 탈퇴를 요청하는 API입니다.")
+	@Operation(summary = "스토어 차단", description = "현재 로그인한 사용자가 특정 스토어를 차단합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "스토어 차단 성공"),
+		@ApiResponse(responseCode = "400", description = "자기 자신은 차단할 수 없습니다."),
+		@ApiResponse(responseCode = "404", description = "스토어를 찾을 수 없습니다.")
+	})
+	@PostMapping("/block/{storeId}")
+	ResponseEntity<SuccessResponse<Void>> blockStore(
+		@Parameter(description = "차단 대상 스토어 ID")
+		@PathVariable("storeId") Long opponentStoreId,
+
+		@Parameter(hidden = true)
+		@CurrentMember Long myStoreId
+	);
+
+	@Operation(summary = "스토어 차단 해제", description = "현재 로그인한 사용자가 특정 스토어 차단을 해제합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "스토어 차단 해제 성공"),
+		@ApiResponse(responseCode = "404", description = "차단 정보 또는 스토어를 찾을 수 없습니다.")
+	})
+	@PostMapping("/unblock/{storeId}")
+	ResponseEntity<SuccessResponse<Void>> unblockStore(
+		@Parameter(description = "차단 해제 대상 스토어 ID")
+		@PathVariable("storeId") Long opponentStoreId,
+
+		@Parameter(hidden = true)
+		@CurrentMember Long myStoreId
+	);
+
+
+	@Operation(summary = "스토어 탈퇴", description = "스토어 회원 탈퇴를 요청하는 API입니다. 신고 승인된 유저도 요청 가능합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "스토어 탈퇴 성공",
 			content = @Content(schema = @Schema(implementation = StoreWithdrawResponse.class))),
@@ -194,5 +303,100 @@ public interface StoreApi {
 	})
 	@PostMapping("/admin/sync-redis/slangs")
 	ResponseEntity<SuccessResponse<Void>> syncSlangToRedis(@CurrentMember Long currentStoreId);
+
+	@Operation(summary = "스토어 역할 변경", description = "스토어 역할을 변경합니다. 테스트용 API입니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "스토어 역할 변경 성공"),
+		@ApiResponse(responseCode = "404", description = "스토어를 찾을 수 없습니다.")
+	})
+	@PatchMapping("/role/{storeId}")
+	ResponseEntity<SuccessResponse<Void>> changeStoreRole(
+		@Parameter(description = "역할을 변경할 스토어 ID")
+		@PathVariable("storeId") Long storeId,
+
+		@io.swagger.v3.oas.annotations.parameters.RequestBody(
+			description = "변경할 역할 정보", required = true,
+			content = @Content(schema = @Schema(implementation = RoleDto.class))
+		)
+		@RequestBody RoleDto roleDto
+	);
+
+	@Operation(summary = "미사용 스토어 이미지 정리", description = "사용되지 않는 스토어 이미지를 정리합니다. 관리자 전용 API입니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "미사용 스토어 이미지 정리 성공"),
+		@ApiResponse(responseCode = "403", description = "관리자 권한이 없습니다.")
+	})
+	@PostMapping("/clean")
+	ResponseEntity<SuccessResponse<Void>> storePhotoCleanUp(
+		@Parameter(hidden = true)
+		@CurrentMember Long currentStoreId
+	);
+
+	@Operation(summary = "토큰 재발급", description = "기존 Refresh Token을 Authorization 헤더로 전달받아 Access Token과 Refresh Token을 재발급합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
+			content = @Content(schema = @Schema(implementation = TokensReissueResponse.class))),
+		@ApiResponse(responseCode = "401", description = "유효하지 않은 Authorization 헤더 또는 Refresh Token"),
+		@ApiResponse(responseCode = "404", description = "스토어를 찾을 수 없습니다.")
+	})
+	@PostMapping("/reissue-tokens")
+	ResponseEntity<SuccessResponse<TokensReissueResponse>> reissueTokens(
+		@Parameter(hidden = true)
+		HttpServletRequest request,
+
+		@Parameter(hidden = true)
+		@CurrentMember Long currentStoreId
+	);
+
+	@Operation(summary = "번호 인증 상태 조회", description = "현재 로그인한 사용자의 번호 인증 완료 여부를 조회합니다. 상품 등록 또는 채팅 메시지 발송 전 인증 필요 여부 확인에 사용합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "번호 인증 상태 조회 성공",
+			content = @Content(schema = @Schema(implementation = PhoneVerificationStatusResponse.class))),
+		@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+		@ApiResponse(responseCode = "404", description = "스토어를 찾을 수 없습니다.")
+	})
+	@GetMapping("/phone-verification-status")
+	ResponseEntity<SuccessResponse<PhoneVerificationStatusResponse>> getPhoneVerificationStatus(
+		@Parameter(hidden = true)
+		@CurrentMember Long currentStoreId
+	);
+
+	@Operation(summary = "번호 인증번호 발송", description = "입력한 전화번호로 인증번호를 발송합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "인증번호 발송 성공",
+			content = @Content(schema = @Schema(implementation = SmsSendResponse.class))),
+		@ApiResponse(responseCode = "400", description = "잘못된 전화번호 형식 또는 일일 발송 한도 초과"),
+		@ApiResponse(responseCode = "409", description = "이미 사용 중인 전화번호 또는 이미 인증된 사용자")
+	})
+	@PostMapping("/phone-verifications/send")
+	ResponseEntity<SuccessResponse<SmsSendResponse>> sendVerificationCode(
+		@io.swagger.v3.oas.annotations.parameters.RequestBody(
+			description = "인증번호 발송 요청", required = true,
+			content = @Content(schema = @Schema(implementation = SmsSendRequest.class))
+		)
+		@Valid @RequestBody SmsSendRequest request,
+
+		@Parameter(hidden = true)
+		@CurrentMember Long currentStoreId
+	);
+
+	@Operation(summary = "번호 인증번호 검증", description = "전화번호와 인증번호를 검증하고, 성공 시 현재 스토어의 번호 인증 상태를 완료 처리합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "인증번호 검증 성공",
+			content = @Content(schema = @Schema(implementation = SmsConfirmResponse.class))),
+		@ApiResponse(responseCode = "400", description = "인증 세션 없음, 인증번호 불일치 또는 검증 실패 횟수 초과"),
+		@ApiResponse(responseCode = "409", description = "이미 사용 중인 전화번호 또는 이미 인증된 사용자")
+	})
+	@PostMapping("/phone-verifications/confirm")
+	ResponseEntity<SuccessResponse<SmsConfirmResponse>> confirmVerificationCode(
+		@io.swagger.v3.oas.annotations.parameters.RequestBody(
+			description = "인증번호 검증 요청", required = true,
+			content = @Content(schema = @Schema(implementation = SmsConfirmRequest.class))
+		)
+		@Valid @RequestBody SmsConfirmRequest request,
+
+		@Parameter(hidden = true)
+		@CurrentMember Long currentStoreId
+	);
 
 }

--- a/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/controller/StoreController.java
@@ -42,6 +42,7 @@ import com.napzak.api.domain.store.dto.response.AccessTokenGenerateResponse;
 import com.napzak.api.domain.store.dto.response.LoginSuccessResponse;
 import com.napzak.api.domain.store.dto.response.MyPageResponse;
 import com.napzak.api.domain.store.dto.response.OnboardingTermsListResponse;
+import com.napzak.api.domain.store.dto.response.PhoneVerificationStatusResponse;
 import com.napzak.api.domain.store.dto.response.SettingLinkResponse;
 import com.napzak.api.domain.store.dto.response.SmsConfirmResponse;
 import com.napzak.api.domain.store.dto.response.SmsSendResponse;
@@ -310,7 +311,7 @@ public class StoreController implements StoreApi {
 	}
 
 	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING, Role.WITHDRAWN})
-	@PostMapping("genres/register")
+	@PostMapping("/genres/register")
 	public ResponseEntity<SuccessResponse<GenreNameListResponse>> register(
 		@CurrentMember final Long currentStoreId,
 		@Valid @RequestBody final GenrePreferenceRequest genrePreferenceList
@@ -460,6 +461,18 @@ public class StoreController implements StoreApi {
 	}
 
 	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING})
+	@GetMapping("/phone-verification-status")
+	public ResponseEntity<SuccessResponse<PhoneVerificationStatusResponse>> getPhoneVerificationStatus(
+		@CurrentMember final Long currentStoreId
+	) {
+		boolean isPhoneVerified = storeService.getPhoneVerificationStatus(currentStoreId);
+		PhoneVerificationStatusResponse response = PhoneVerificationStatusResponse.of(isPhoneVerified);
+
+		return ResponseEntity.ok(
+			SuccessResponse.of(StoreSuccessCode.STORE_PHONE_VERIFIED_GET_SUCCESS, response));
+	}
+
+	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING})
 	@PostMapping("/phone-verifications/send")
 	public ResponseEntity<SuccessResponse<SmsSendResponse>> sendVerificationCode(
 		@Valid @RequestBody SmsSendRequest request,
@@ -470,7 +483,6 @@ public class StoreController implements StoreApi {
 		return ResponseEntity.ok()
 			.body(SuccessResponse.of(SmsSuccessCode.VERIFICATION_CODE_SEND_SUCCESS, response));
 	}
-
 
 	@AuthorizedRole({Role.ADMIN, Role.STORE, Role.ONBOARDING})
 	@PostMapping("/phone-verifications/confirm")

--- a/api-server/src/main/java/com/napzak/api/domain/store/dto/response/PhoneVerificationStatusResponse.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/dto/response/PhoneVerificationStatusResponse.java
@@ -1,0 +1,13 @@
+package com.napzak.api.domain.store.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record PhoneVerificationStatusResponse(
+	@JsonProperty("isPhoneVerified")
+	boolean isPhoneVerified
+) {
+
+	public static PhoneVerificationStatusResponse of(final boolean isPhoneVerified) {
+		return new PhoneVerificationStatusResponse(isPhoneVerified);
+	}
+}

--- a/api-server/src/main/java/com/napzak/api/domain/store/service/StoreService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/service/StoreService.java
@@ -78,6 +78,13 @@ public class StoreService {
 	}
 
 	@Transactional(readOnly = true)
+	public boolean getPhoneVerificationStatus(final Long storeId) {
+		Store store = getStore(storeId);
+
+		return store.isPhoneVerified();
+	}
+
+	@Transactional(readOnly = true)
 	public Role findRoleByStoreId(final Long storeId) {
 		return storeRetriever.findRoleByStoreId(storeId);
 	}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #268 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 현재 로그인한 사용자의 번호 인증 완료 여부를 조회하는 API를 추가했습니다.
  - `GET /api/v1/stores/phone-verification-status`
  - 응답 필드: `isPhoneVerified`

- 번호 인증 상태 조회 응답 DTO를 추가했습니다.
  - `PhoneVerificationStatusResponse`

- `StoreService`에 번호 인증 상태 조회 로직을 추가했습니다.
  - 기존 `getStore()` 로직을 재사용하여 스토어 존재 여부 검증을 유지했습니다.
  - 조회된 Store의 `phoneVerified` 값을 반환합니다.

- `StoreController`에 번호 인증 상태 조회 엔드포인트를 추가했습니다.
  - 접근 가능 Role: `ADMIN`, `STORE`, `ONBOARDING`
  - 상품 등록 및 채팅 메시지 발송 전 번호 인증 필요 여부를 확인하는 용도로 사용됩니다.

- `StoreApi`에 누락되어 있던 Swagger 문서를 보완했습니다.
  - 번호 인증 상태 조회 API
  - 인증번호 발송/검증 API
  - 카카오 로그인 API
  - 스토어 ID 조회 API
  - 마이페이지 설정 링크 조회 API
  - 약관 조회/동의 API
  - 차단/차단 해제 API
  - 토큰 재발급 API 등

### 응답 예시
```json
{
  "status": 200,
  "message": "번호 인증 상태 조회에 성공했습니다.",
  "data": {
    "isPhoneVerified": false
  }
}
```
## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
번호 인증 상태 조회 API는 Redis 인증 세션을 조회하지 않고, Store의 phoneVerified 값만 조회합니다.
인증번호 발송/검증 로직과 분리하여 단순 상태 조회 API로 구성했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 카카오 소셜 로그인 추가
* 전화번호 인증 기능 추가 (인증코드 발송 및 확인)
* 스토어 차단/차단 해제 기능 추가
* 온보딩 약관 관리 및 동의 기능 추가
* 토큰 재발급 기능 추가
* 마이페이지 설정 및 스토어 정보 조회 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->