### PR TITLE
[Feat] #270 - 회원가입 시 Slack Webhook 알림 발송 구현

### DIFF
--- a/common-module/src/main/java/com/napzak/common/util/slack/SlackWebhookProperties.java
+++ b/common-module/src/main/java/com/napzak/common/util/slack/SlackWebhookProperties.java
@@ -6,5 +6,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record SlackWebhookProperties(
 	String withdraw,
 	String storeReport,
-	String productReport
+	String productReport,
+	String signup
 ) {}

--- a/common-module/src/main/java/com/napzak/common/util/slack/SlackWebhookSender.java
+++ b/common-module/src/main/java/com/napzak/common/util/slack/SlackWebhookSender.java
@@ -1,15 +1,20 @@
 package com.napzak.common.util.slack;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
@@ -20,6 +25,7 @@ public class SlackWebhookSender {
 
 	private final SlackWebhookProperties webhookProperties;
 	private final RestTemplate restTemplate;
+	private final Environment environment;
 
 	public void send(String webhookUrl, String text) {
 		if (webhookUrl == null || webhookUrl.isBlank()) {
@@ -27,6 +33,21 @@ public class SlackWebhookSender {
 			return;
 		}
 
+		if (TransactionSynchronizationManager.isSynchronizationActive()
+			&& TransactionSynchronizationManager.isActualTransactionActive()) {
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+				@Override
+				public void afterCommit() {
+					sendImmediately(webhookUrl, text);
+				}
+			});
+			return;
+		}
+
+		sendImmediately(webhookUrl, text);
+	}
+
+	private void sendImmediately(String webhookUrl, String text) {
 		Map<String, Object> body = Map.of("text", text);
 
 		HttpHeaders headers = new HttpHeaders();
@@ -48,6 +69,24 @@ public class SlackWebhookSender {
 		}
 	}
 
+	public String getCurrentEnvironment() {
+		List<String> activeProfiles = Arrays.asList(environment.getActiveProfiles());
+
+		if (activeProfiles.contains("prod")) {
+			return "prod";
+		}
+
+		if (activeProfiles.contains("dev")) {
+			return "dev";
+		}
+
+		if (activeProfiles.isEmpty()) {
+			return "local";
+		}
+
+		return String.join(",", activeProfiles);
+	}
+
 	public void sendWithdraw(String message) {
 		send(webhookProperties.withdraw(), message);
 	}
@@ -58,5 +97,9 @@ public class SlackWebhookSender {
 
 	public void sendProductReport(String message) {
 		send(webhookProperties.productReport(), message);
+	}
+
+	public void sendSignup(String message) {
+		send(webhookProperties.signup(), message);
 	}
 }

--- a/core-domain/src/main/java/com/napzak/domain/product/crud/productreport/ProductReportSaver.java
+++ b/core-domain/src/main/java/com/napzak/domain/product/crud/productreport/ProductReportSaver.java
@@ -52,6 +52,7 @@ public class ProductReportSaver {
 			• *상품 ID:* %d
 			• *연락처:* %s
 			• *신고 시각:* %s
+			• *환경:* `%s`
 
 			*상품 정보*
 			• *상품 제목:* %s
@@ -70,6 +71,7 @@ public class ProductReportSaver {
 			entity.getReportedProductId(),
 			entity.getReportContact(),
 			entity.getCreatedAt(),
+			slackWebhookSender.getCurrentEnvironment(),
 			entity.getReportedProductTitle(),
 			entity.getReportedProductDescription(),
 			entity.getReportTitle(),

--- a/core-domain/src/main/java/com/napzak/domain/store/crud/store/StoreUpdater.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/crud/store/StoreUpdater.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.napzak.common.util.encryption.PhoneEncryptionUtil;
+import com.napzak.common.util.slack.SlackWebhookSender;
 import com.napzak.domain.store.code.StoreErrorCode;
 import com.napzak.domain.store.entity.StoreEntity;
 import com.napzak.domain.store.repository.StoreRepository;
@@ -18,6 +19,7 @@ public class StoreUpdater {
 
 	private final StoreRepository storeRepository;
 	private final PhoneEncryptionUtil phoneEncryptionUtil;
+	private final SlackWebhookSender slackWebhookSender;
 
 	@Transactional
 	public void registerNicknameAndSetRoleAndPhoto(final Long storeId, final String nickname,
@@ -29,6 +31,19 @@ public class StoreUpdater {
 		storeEntity.setPhoto(profileUrl);
 		storeEntity.setCover(coverUrl);
 		storeRepository.save(storeEntity);
+
+		long totalStoreCount = storeRepository.count();
+
+		slackWebhookSender.sendSignup("""
+			🎉 *새로운 납자기 `%s` 등장!* 🎉
+			
+			• *누적 가입 회원 수:* %,d명
+			• *환경:* `%s`
+			""".formatted(
+			storeEntity.getNickname(),
+			totalStoreCount,
+			slackWebhookSender.getCurrentEnvironment()
+		));
 	}
 
 	@Transactional

--- a/core-domain/src/main/java/com/napzak/domain/store/crud/storereport/StoreReportSaver.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/crud/storereport/StoreReportSaver.java
@@ -41,6 +41,7 @@ public class StoreReportSaver {
 			• *닉네임:* %s
 			• *연락처:* %s
 			• *신고 시각:* %s
+			• *환경:* `%s`
 
 			*상점 정보*
 			• *프로필:* %s
@@ -58,6 +59,7 @@ public class StoreReportSaver {
 			entity.getReportedStoreNickname(),
 			entity.getReportContact(),
 			entity.getCreatedAt(),
+			slackWebhookSender.getCurrentEnvironment(),
 			entity.getReportedStoreProfile(),
 			entity.getReportedStoreCover(),
 			entity.getReportedStoreDescription(),

--- a/core-domain/src/main/java/com/napzak/domain/store/crud/withdraw/WithdrawSaver.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/crud/withdraw/WithdrawSaver.java
@@ -32,6 +32,7 @@ public class WithdrawSaver {
 			• *탈퇴 회원 ID:* %s
 			• *제목:* %s
 			• *탈퇴 시각:* %s
+			• *환경:* `%s`
 
 			*상세 내용*
 			%s
@@ -39,6 +40,7 @@ public class WithdrawSaver {
 			entity.getWithdrawerId(),
 			entity.getTitle(),
 			entity.getCreatedAt(),
+			slackWebhookSender.getCurrentEnvironment(),
 			entity.getDescription()
 		));
 


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #270 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
회원가입 시 Slack Webhook 알림을 발송하도록 추가했습니다.

닉네임 등록이 완료되는 온보딩 마무리 시점에 회원가입 알림을 전송하며, 알림에는 신규 회원 닉네임, 누적 가입 회원 수, 실행 환경 정보를 포함했습니다.

또한 기존 탈퇴/상점 신고/상품 신고 Slack 알림에도 실행 환경 정보를 추가했습니다.

### 주요 변경사항

- 회원가입 완료 Slack 알림 추가
  - 닉네임 등록 완료 시 알림 발송
  - 신규 회원 닉네임 표시
  - 전체 Store 수 기준 누적 가입 회원 수 표시
  - active profile 기준 실행 환경 표시

- 기존 Slack 알림 메시지 개선
  - 회원 탈퇴 알림에 실행 환경 추가
  - 상점 신고 알림에 실행 환경 추가
  - 상품 신고 알림에 실행 환경 추가

- Slack Webhook 발송 시점 개선
  - 트랜잭션이 존재하는 경우 커밋 이후 Slack Webhook 발송
  - DB 저장이 롤백된 경우 Slack 알림이 발송되지 않도록 처리
  - 트랜잭션이 없는 경우 기존처럼 즉시 발송

### 동작 방식

SlackWebhookSender에서 현재 트랜잭션 여부를 확인합니다.

트랜잭션이 활성화된 경우에는 Webhook을 즉시 발송하지 않고 afterCommit에 등록하여 DB 커밋 이후 발송합니다.

트랜잭션이 없는 경우에는 기존과 동일하게 즉시 발송합니다.

### Slack 알림 예시

```text
🎉 새로운 납자기 `도토리상점` 등장! 🎉

• 누적 가입 회원 수: 1,284명
• 환경: dev
```
### 기대 효과
온보딩 완료 회원 발생 시 팀에서 실시간으로 가입 현황 확인 가능
dev/prod 환경 구분이 가능해져 운영 알림 확인 안정성 개선
DB 반영 실패 시 Slack 알림만 발송되는 불일치 상황 방지

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 신규 가입 Slack 알림 기능 추가

## 개선사항
* 상품 신고, 매장 신고, 인출 등 Slack 알림에 현재 실행 환경 정보 포함
* Spring 트랜잭션 커밋 이후 Slack 메시지 전송으로 안정성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->