### PR TITLE
[fix] #272 - 올바르지 않은 전화번호 형식을 service단에서 검증하고 예외 호출하도록 수정

### DIFF
--- a/api-server/src/main/java/com/napzak/api/domain/store/dto/request/SmsConfirmRequest.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/dto/request/SmsConfirmRequest.java
@@ -1,13 +1,12 @@
 package com.napzak.api.domain.store.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 
 public record SmsConfirmRequest(
-	@NotBlank @Pattern(regexp = "^01[016789]\\d{7,8}$", message = "올바른 휴대폰 번호 형식이 아닙니다.")
+	@NotBlank
 	String phoneNumber,
 
-	@NotBlank @Pattern(regexp = "^\\d{6}$", message = "올바른 인증 번호 형식이 아닙니다.")
+	@NotBlank
 	String code
 ) {
 }

--- a/api-server/src/main/java/com/napzak/api/domain/store/dto/request/SmsSendRequest.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/dto/request/SmsSendRequest.java
@@ -1,10 +1,9 @@
 package com.napzak.api.domain.store.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 
 public record SmsSendRequest(
-	@NotBlank @Pattern(regexp = "^01[016789]\\d{7,8}$", message = "올바른 휴대폰 번호 형식이 아닙니다.")
+	@NotBlank
 	String phoneNumber
 ) {
 }

--- a/api-server/src/main/java/com/napzak/api/domain/store/service/SmsService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/service/SmsService.java
@@ -1,6 +1,7 @@
 package com.napzak.api.domain.store.service;
 
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import org.springframework.stereotype.Service;
 
@@ -34,6 +35,10 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class SmsService {
 
+	private static final Pattern PHONE_NUMBER_PATTERN = Pattern.compile("^01[016789]\\d{7,8}$");
+	private static final Pattern VERIFICATION_CODE_PATTERN = Pattern.compile("^\\d{6}$");
+
+
 	private final SmsUtil smsUtil;
 	private final SmsProperties smsProperties;
 	private final PhoneEncryptionUtil phoneEncryptionUtil;
@@ -49,7 +54,7 @@ public class SmsService {
 	public SmsSendResponse sendVerificationCode(SmsSendRequest request, Long storeId) {
 		String phoneNumber = request.phoneNumber();
 
-		if (!phoneNumber.matches("^01[016789]\\d{7,8}$")) {
+		if (!PHONE_NUMBER_PATTERN.matcher(phoneNumber).matches()) {
 			throw new NapzakException(SmsErrorCode.INVALID_PHONE_NUMBER_FORMAT);
 		}
 
@@ -88,10 +93,10 @@ public class SmsService {
 	public SmsConfirmResponse confirmVerificationCode(SmsConfirmRequest request, Long storeId) {
 		String phoneNumber = request.phoneNumber();
 
-		if (!phoneNumber.matches("^01[016789]\\d{7,8}$")) {
+		if (!PHONE_NUMBER_PATTERN.matcher(phoneNumber).matches()) {
 			throw new NapzakException(SmsErrorCode.INVALID_PHONE_NUMBER_FORMAT);
 		}
-		if (!request.code().matches("^\\d{6}$")) {
+		if (!VERIFICATION_CODE_PATTERN.matcher(request.code()).matches()) {
 			throw new NapzakException(SmsErrorCode.INVALID_CODE_FORMAT);
 		}
 

--- a/api-server/src/main/java/com/napzak/api/domain/store/service/SmsService.java
+++ b/api-server/src/main/java/com/napzak/api/domain/store/service/SmsService.java
@@ -49,6 +49,10 @@ public class SmsService {
 	public SmsSendResponse sendVerificationCode(SmsSendRequest request, Long storeId) {
 		String phoneNumber = request.phoneNumber();
 
+		if (!phoneNumber.matches("^01[016789]\\d{7,8}$")) {
+			throw new NapzakException(SmsErrorCode.INVALID_PHONE_NUMBER_FORMAT);
+		}
+
 		// 유효성 검사
 		int remainingCount = validateDailyLimit(phoneNumber);
 		validatePhoneNumberUsage(phoneNumber, storeId);
@@ -83,6 +87,13 @@ public class SmsService {
 
 	public SmsConfirmResponse confirmVerificationCode(SmsConfirmRequest request, Long storeId) {
 		String phoneNumber = request.phoneNumber();
+
+		if (!phoneNumber.matches("^01[016789]\\d{7,8}$")) {
+			throw new NapzakException(SmsErrorCode.INVALID_PHONE_NUMBER_FORMAT);
+		}
+		if (!request.code().matches("^\\d{6}$")) {
+			throw new NapzakException(SmsErrorCode.INVALID_CODE_FORMAT);
+		}
 
 		// 인증번호 요청과 검증 사이에 같은 번호가 가입되었는지 검증
 		validatePhoneNumberUsage(phoneNumber, storeId);

--- a/core-domain/src/main/java/com/napzak/domain/store/code/SmsErrorCode.java
+++ b/core-domain/src/main/java/com/napzak/domain/store/code/SmsErrorCode.java
@@ -12,6 +12,12 @@ import lombok.RequiredArgsConstructor;
 public enum SmsErrorCode implements BaseErrorCode {
 
 	/*
+	400 BAD REQUEST
+	 */
+	INVALID_PHONE_NUMBER_FORMAT(HttpStatus.BAD_REQUEST, "올바른 휴대폰 번호 형식이 아닙니다."),
+	INVALID_CODE_FORMAT(HttpStatus.BAD_REQUEST, "올바른 인증 번호 형식이 아닙니다."),
+
+	/*
 	404 NOT FOUND
 	 */
 	VERIFICATION_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "인증번호가 만료되었거나 존재하지 않습니다. 다시 요청해주세요."),


### PR DESCRIPTION
…e단에서 직접 예외 호출하도록 수정

## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #272 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
기존에는 request dto 내부에서 @Pattern으로 정규식 검사를 통해 전화번호 형식을 검증했는데, 이렇게 했을 때 globalExceptionHandler에서 잡혀 추가 예외메시지가 반환되고, 프론트 측에서 대응불가해 '잘못된 전화번호 형식' 토스트바가 아닌 '서버 에러' 토스트바가 띄워지는 이슈가 있었습니다. 서비스 단 내에서 검증을 수행해 직접 예외를 던지도록 수정하였습니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **개선**
  * SMS 인증 요청 시 전화번호 및 검증 코드 형식 검증을 강화하고, 형식 오류 시 더 명확한 에러 메시지 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->