### PR TITLE
[feat] #285 - dev 환경 secret 주입 방식 개선 및 Docker image secret 제거

### DIFF
--- a/.github/workflows/dev-CD.yml
+++ b/.github/workflows/dev-CD.yml
@@ -30,13 +30,13 @@ jobs:
       - name: Inject API secrets
         env:
           API_APPLICATION_DEV: ${{ secrets.API_APPLICATION_DEV }}
-          API_FIREBASE_JSON: ${{ secrets.API_FIREBASE_JSON }}
+          API_FIREBASE_JSON_BASE64: ${{ secrets.API_FIREBASE_JSON_BASE64 }}
         run: |
           mkdir -p api-server/src/main/resources
           printf '%s\n' "$API_APPLICATION_DEV" > api-server/src/main/resources/application-dev.yml
 
           mkdir -p api-server/src/main/resources/firebase
-          printf '%s\n' "$API_FIREBASE_JSON" > api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+          printf '%s' "$API_FIREBASE_JSON_BASE64" | tr -d '\n\r ' | base64 -d > api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
 
           echo "API application-dev.yml size:"
           wc -c api-server/src/main/resources/application-dev.yml
@@ -44,22 +44,36 @@ jobs:
           grep -q '^jwt:' api-server/src/main/resources/application-dev.yml
           grep -q '^[[:space:]]*secret:' api-server/src/main/resources/application-dev.yml
 
+          echo "API firebase json size:"
+          wc -c api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+          test -s api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+          python3 -m json.tool api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json >/dev/null
+          grep -q '"type"[[:space:]]*:[[:space:]]*"service_account"' api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+          grep -q '"private_key"' api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+
       - name: Inject Chat secrets
         env:
           CHAT_APPLICATION_DEV: ${{ secrets.CHAT_APPLICATION_DEV }}
-          CHAT_FIREBASE_JSON: ${{ secrets.CHAT_FIREBASE_JSON }}
+          CHAT_FIREBASE_JSON_BASE64: ${{ secrets.CHAT_FIREBASE_JSON_BASE64 }}
         run: |
           mkdir -p chat-server/src/main/resources
           printf '%s\n' "$CHAT_APPLICATION_DEV" > chat-server/src/main/resources/application-dev.yml
 
           mkdir -p chat-server/src/main/resources/firebase
-          printf '%s\n' "$CHAT_FIREBASE_JSON" > chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+          printf '%s' "$CHAT_FIREBASE_JSON_BASE64" | tr -d '\n\r ' | base64 -d > chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
 
           echo "CHAT application-dev.yml size:"
           wc -c chat-server/src/main/resources/application-dev.yml
           test -s chat-server/src/main/resources/application-dev.yml
           grep -q '^jwt:' chat-server/src/main/resources/application-dev.yml
           grep -q '^[[:space:]]*secret:' chat-server/src/main/resources/application-dev.yml
+
+          echo "CHAT firebase json size:"
+          wc -c chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+          test -s chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+          python3 -m json.tool chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json >/dev/null
+          grep -q '"type"[[:space:]]*:[[:space:]]*"service_account"' chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+          grep -q '"private_key"' chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/dev-CD.yml
+++ b/.github/workflows/dev-CD.yml
@@ -22,59 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'corretto'
-
-      - name: Inject API secrets
-        env:
-          API_APPLICATION_DEV: ${{ secrets.API_APPLICATION_DEV }}
-          API_FIREBASE_JSON_BASE64: ${{ secrets.API_FIREBASE_JSON_BASE64 }}
-        run: |
-          mkdir -p api-server/src/main/resources
-          printf '%s\n' "$API_APPLICATION_DEV" > api-server/src/main/resources/application-dev.yml
-
-          mkdir -p api-server/src/main/resources/firebase
-          printf '%s' "$API_FIREBASE_JSON_BASE64" | tr -d '\n\r ' | base64 -d > api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-
-          echo "API application-dev.yml size:"
-          wc -c api-server/src/main/resources/application-dev.yml
-          test -s api-server/src/main/resources/application-dev.yml
-          grep -q '^jwt:' api-server/src/main/resources/application-dev.yml
-          grep -q '^[[:space:]]*secret:' api-server/src/main/resources/application-dev.yml
-
-          echo "API firebase json size:"
-          wc -c api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-          test -s api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-          python3 -m json.tool api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json >/dev/null
-          grep -q '"type"[[:space:]]*:[[:space:]]*"service_account"' api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-          grep -q '"private_key"' api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-
-      - name: Inject Chat secrets
-        env:
-          CHAT_APPLICATION_DEV: ${{ secrets.CHAT_APPLICATION_DEV }}
-          CHAT_FIREBASE_JSON_BASE64: ${{ secrets.CHAT_FIREBASE_JSON_BASE64 }}
-        run: |
-          mkdir -p chat-server/src/main/resources
-          printf '%s\n' "$CHAT_APPLICATION_DEV" > chat-server/src/main/resources/application-dev.yml
-
-          mkdir -p chat-server/src/main/resources/firebase
-          printf '%s' "$CHAT_FIREBASE_JSON_BASE64" | tr -d '\n\r ' | base64 -d > chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-
-          echo "CHAT application-dev.yml size:"
-          wc -c chat-server/src/main/resources/application-dev.yml
-          test -s chat-server/src/main/resources/application-dev.yml
-          grep -q '^jwt:' chat-server/src/main/resources/application-dev.yml
-          grep -q '^[[:space:]]*secret:' chat-server/src/main/resources/application-dev.yml
-
-          echo "CHAT firebase json size:"
-          wc -c chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-          test -s chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-          python3 -m json.tool chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json >/dev/null
-          grep -q '"type"[[:space:]]*:[[:space:]]*"service_account"' chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-          grep -q '"private_key"' chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -137,10 +84,77 @@ jobs:
           API_ECR_APP_NAME: ${{ env.API_ECR_APP_NAME }}
           CHAT_ECR_APP_NAME: ${{ env.CHAT_ECR_APP_NAME }}
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
+          API_FIREBASE_JSON_BASE64: ${{ secrets.API_FIREBASE_JSON_BASE64 }}
+          CHAT_FIREBASE_JSON_BASE64: ${{ secrets.CHAT_FIREBASE_JSON_BASE64 }}
         with:
           host: ${{ secrets.DEV_SERVER_HOST }}
           username: ${{ secrets.DEV_SERVER_USERNAME }}
           key: ${{ secrets.DEV_SERVER_KEY }}
-          envs: ECR_HOST,API_ECR_APP_NAME,CHAT_ECR_APP_NAME,IMAGE_TAG
+          envs: ECR_HOST,API_ECR_APP_NAME,CHAT_ECR_APP_NAME,IMAGE_TAG,API_FIREBASE_JSON_BASE64,CHAT_FIREBASE_JSON_BASE64
           script: |
+            set -e
+
+            cd /home/ubuntu/Napzak-BE
+
+            validate_jwt_secret() {
+              file="$1"
+              awk '
+                /^jwt:[[:space:]]*$/ { in_jwt=1; next }
+                /^[^[:space:]#][^:]*:/ { if ($0 !~ /^jwt:/) in_jwt=0 }
+                in_jwt && /^[[:space:]]+secret:[[:space:]]*.+/ { found=1 }
+                END { exit found ? 0 : 1 }
+              ' "$file"
+            }
+
+            validate_firebase_json() {
+              file="$1"
+              python3 - "$file" <<'PY'
+            import json
+            import sys
+            from pathlib import Path
+
+            path = Path(sys.argv[1])
+            data = json.loads(path.read_text())
+
+            required = ["type", "project_id", "private_key", "client_email"]
+            missing = [key for key in required if not str(data.get(key, "")).strip()]
+
+            if missing:
+                raise SystemExit(f"missing required firebase fields: {missing}")
+
+            if data["type"] != "service_account":
+                raise SystemExit("firebase type must be service_account")
+            PY
+            }
+
+            umask 077
+            mkdir -p secrets/api secrets/chat
+
+            cat > secrets/api/application-dev.yml <<'EOF_API_APPLICATION_DEV'
+            ${{ secrets.API_APPLICATION_DEV }}
+            EOF_API_APPLICATION_DEV
+
+            cat > secrets/chat/application-dev.yml <<'EOF_CHAT_APPLICATION_DEV'
+            ${{ secrets.CHAT_APPLICATION_DEV }}
+            EOF_CHAT_APPLICATION_DEV
+
+            printf '%s' "$API_FIREBASE_JSON_BASE64" | tr -d '\n\r ' | base64 -d > secrets/api/napzak-firebase-adminsdk.json
+            printf '%s' "$CHAT_FIREBASE_JSON_BASE64" | tr -d '\n\r ' | base64 -d > secrets/chat/napzak-firebase-adminsdk.json
+
+            test -s secrets/api/application-dev.yml
+            test -s secrets/chat/application-dev.yml
+            test -s secrets/api/napzak-firebase-adminsdk.json
+            test -s secrets/chat/napzak-firebase-adminsdk.json
+
+            validate_jwt_secret secrets/api/application-dev.yml
+            validate_jwt_secret secrets/chat/application-dev.yml
+
+            validate_firebase_json secrets/api/napzak-firebase-adminsdk.json
+            validate_firebase_json secrets/chat/napzak-firebase-adminsdk.json
+
+            chmod 600 secrets/api/application-dev.yml
+            chmod 600 secrets/chat/application-dev.yml
+            chmod 600 secrets/api/napzak-firebase-adminsdk.json
+            chmod 600 secrets/chat/napzak-firebase-adminsdk.json
+
             bash /home/ubuntu/deploy-napzak-dev.sh

--- a/.github/workflows/dev-CI.yml
+++ b/.github/workflows/dev-CI.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    environment: dev
 
     steps:
       - uses: actions/checkout@v3
@@ -17,55 +16,53 @@ jobs:
           java-version: '17'
           distribution: 'corretto'
 
-      - name: Inject API secrets
-        env:
-          API_APPLICATION_DEV: ${{ secrets.API_APPLICATION_DEV }}
-          API_FIREBASE_JSON_BASE64: ${{ secrets.API_FIREBASE_JSON_BASE64 }}
+      - name: Inject dummy config
         run: |
-          mkdir -p api-server/src/main/resources
-          printf '%s\n' "$API_APPLICATION_DEV" > api-server/src/main/resources/application-dev.yml
-
           mkdir -p api-server/src/main/resources/firebase
-          printf '%s' "$API_FIREBASE_JSON_BASE64" | tr -d '\n\r ' | base64 -d > api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-
-          echo "API application-dev.yml size:"
-          wc -c api-server/src/main/resources/application-dev.yml
-          test -s api-server/src/main/resources/application-dev.yml
-          grep -q '^jwt:' api-server/src/main/resources/application-dev.yml
-          grep -q '^[[:space:]]*secret:' api-server/src/main/resources/application-dev.yml
-
-          echo "API firebase json size:"
-          wc -c api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-          test -s api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-          python3 -m json.tool api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json >/dev/null
-          grep -q '"type"[[:space:]]*:[[:space:]]*"service_account"' api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-          grep -q '"private_key"' api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-
-      - name: Inject Chat secrets
-        env:
-          CHAT_APPLICATION_DEV: ${{ secrets.CHAT_APPLICATION_DEV }}
-          CHAT_FIREBASE_JSON_BASE64: ${{ secrets.CHAT_FIREBASE_JSON_BASE64 }}
-        run: |
-          mkdir -p chat-server/src/main/resources
-          printf '%s\n' "$CHAT_APPLICATION_DEV" > chat-server/src/main/resources/application-dev.yml
-
           mkdir -p chat-server/src/main/resources/firebase
-          printf '%s' "$CHAT_FIREBASE_JSON_BASE64" | tr -d '\n\r ' | base64 -d > chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
 
-          echo "CHAT application-dev.yml size:"
-          wc -c chat-server/src/main/resources/application-dev.yml
+          cat > api-server/src/main/resources/application-dev.yml <<'EOF'
+          jwt:
+            secret: ci-dummy-jwt-secret-for-build-only-ci-dummy-jwt-secret
+          firebase:
+            config-path: classpath:firebase/napzak-firebase-adminsdk.json
+          EOF
+
+          cp api-server/src/main/resources/application-dev.yml \
+             chat-server/src/main/resources/application-dev.yml
+
+          cat > api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json <<'EOF'
+          {
+            "type": "service_account",
+            "project_id": "dummy-project",
+            "private_key_id": "dummy-private-key-id",
+            "private_key": "-----BEGIN PRIVATE KEY-----\nDUMMY\n-----END PRIVATE KEY-----\n",
+            "client_email": "dummy@dummy-project.iam.gserviceaccount.com",
+            "client_id": "dummy-client-id",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+            "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/dummy%40dummy-project.iam.gserviceaccount.com",
+            "universe_domain": "googleapis.com"
+          }
+          EOF
+
+          cp api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json \
+             chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+
+      - name: Validate dummy config
+        run: |
+          set -e
+
+          test -s api-server/src/main/resources/application-dev.yml
           test -s chat-server/src/main/resources/application-dev.yml
-          grep -q '^jwt:' chat-server/src/main/resources/application-dev.yml
-          grep -q '^[[:space:]]*secret:' chat-server/src/main/resources/application-dev.yml
-
-          echo "CHAT firebase json size:"
-          wc -c chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+          test -s api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
           test -s chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-          python3 -m json.tool chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json >/dev/null
-          grep -q '"type"[[:space:]]*:[[:space:]]*"service_account"' chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-          grep -q '"private_key"' chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
 
-      - name: Build (Gradle)
+          python3 -m json.tool api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json >/dev/null
+          python3 -m json.tool chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json >/dev/null
+
+      - name: Build Gradle
         run: |
           chmod +x ./gradlew
           ./gradlew clean build -x test

--- a/.github/workflows/dev-CI.yml
+++ b/.github/workflows/dev-CI.yml
@@ -1,4 +1,3 @@
-# dev-CI.yml
 name: dev-CI
 
 on:
@@ -18,17 +17,16 @@ jobs:
           java-version: '17'
           distribution: 'corretto'
 
-      # Secret 파일 주입 (API)
       - name: Inject API secrets
         env:
           API_APPLICATION_DEV: ${{ secrets.API_APPLICATION_DEV }}
-          API_FIREBASE_JSON: ${{ secrets.API_FIREBASE_JSON }}
+          API_FIREBASE_JSON_BASE64: ${{ secrets.API_FIREBASE_JSON_BASE64 }}
         run: |
           mkdir -p api-server/src/main/resources
           printf '%s\n' "$API_APPLICATION_DEV" > api-server/src/main/resources/application-dev.yml
 
           mkdir -p api-server/src/main/resources/firebase
-          printf '%s\n' "$API_FIREBASE_JSON" > api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+          printf '%s' "$API_FIREBASE_JSON_BASE64" | tr -d '\n\r ' | base64 -d > api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
 
           echo "API application-dev.yml size:"
           wc -c api-server/src/main/resources/application-dev.yml
@@ -36,23 +34,36 @@ jobs:
           grep -q '^jwt:' api-server/src/main/resources/application-dev.yml
           grep -q '^[[:space:]]*secret:' api-server/src/main/resources/application-dev.yml
 
-      # Secret 파일 주입 (Chat)
+          echo "API firebase json size:"
+          wc -c api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+          test -s api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+          python3 -m json.tool api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json >/dev/null
+          grep -q '"type"[[:space:]]*:[[:space:]]*"service_account"' api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+          grep -q '"private_key"' api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+
       - name: Inject Chat secrets
         env:
           CHAT_APPLICATION_DEV: ${{ secrets.CHAT_APPLICATION_DEV }}
-          CHAT_FIREBASE_JSON: ${{ secrets.CHAT_FIREBASE_JSON }}
+          CHAT_FIREBASE_JSON_BASE64: ${{ secrets.CHAT_FIREBASE_JSON_BASE64 }}
         run: |
           mkdir -p chat-server/src/main/resources
           printf '%s\n' "$CHAT_APPLICATION_DEV" > chat-server/src/main/resources/application-dev.yml
 
           mkdir -p chat-server/src/main/resources/firebase
-          printf '%s\n' "$CHAT_FIREBASE_JSON" > chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+          printf '%s' "$CHAT_FIREBASE_JSON_BASE64" | tr -d '\n\r ' | base64 -d > chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
 
           echo "CHAT application-dev.yml size:"
           wc -c chat-server/src/main/resources/application-dev.yml
           test -s chat-server/src/main/resources/application-dev.yml
           grep -q '^jwt:' chat-server/src/main/resources/application-dev.yml
           grep -q '^[[:space:]]*secret:' chat-server/src/main/resources/application-dev.yml
+
+          echo "CHAT firebase json size:"
+          wc -c chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+          test -s chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+          python3 -m json.tool chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json >/dev/null
+          grep -q '"type"[[:space:]]*:[[:space:]]*"service_account"' chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
+          grep -q '"private_key"' chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
 
       - name: Build (Gradle)
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,6 @@ build/
 
 ## Ignore Qclass
 **/src/main/generated/
+
+# Ignore runtime secrets
+secrets/

--- a/Dockerfile-api-dev
+++ b/Dockerfile-api-dev
@@ -5,12 +5,17 @@ WORKDIR /usr/src/app
 
 COPY . .
 
-# ✅ Docker build context 안에 secret yml이 실제로 들어왔는지 검증
+# Docker build context 안에 secret yml/json이 실제로 들어왔는지 검증
 RUN echo "API yml in builder:" && \
     wc -c api-server/src/main/resources/application-dev.yml && \
     test -s api-server/src/main/resources/application-dev.yml && \
     grep -q "jwt:" api-server/src/main/resources/application-dev.yml && \
-    grep -q "secret:" api-server/src/main/resources/application-dev.yml
+    grep -q "secret:" api-server/src/main/resources/application-dev.yml && \
+    echo "API firebase json in builder:" && \
+    wc -c api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json && \
+    test -s api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json && \
+    grep -q '"type"[[:space:]]*:[[:space:]]*"service_account"' api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json && \
+    grep -q '"private_key"' api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
 
 RUN chmod +x ./gradlew && ./gradlew :api-server:bootJar -x test
 
@@ -26,16 +31,21 @@ ENV JAVA_TOOL_OPTIONS="-Duser.timezone=Asia/Seoul -Xms128m -Xmx384m"
 
 WORKDIR /app
 
-# ✅ runtime에도 secret yml 복사
+# runtime에도 secret yml/json 복사
 COPY api-server/src/main/resources/application-dev.yml /app/application-dev.yml
 COPY api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json /app/firebase/napzak-firebase-adminsdk.json
 
-# ✅ runtime 파일도 0바이트면 이미지 빌드 실패
+# runtime 파일도 0바이트면 이미지 빌드 실패
 RUN echo "API yml in runtime:" && \
     wc -c /app/application-dev.yml && \
     test -s /app/application-dev.yml && \
     grep -q "jwt:" /app/application-dev.yml && \
-    grep -q "secret:" /app/application-dev.yml
+    grep -q "secret:" /app/application-dev.yml && \
+    echo "API firebase json in runtime:" && \
+    wc -c /app/firebase/napzak-firebase-adminsdk.json && \
+    test -s /app/firebase/napzak-firebase-adminsdk.json && \
+    grep -q '"type"[[:space:]]*:[[:space:]]*"service_account"' /app/firebase/napzak-firebase-adminsdk.json && \
+    grep -q '"private_key"' /app/firebase/napzak-firebase-adminsdk.json
 
 COPY --from=builder /usr/src/app/api-server/build/libs/api-server.jar /app/api-server.jar
 

--- a/Dockerfile-api-dev
+++ b/Dockerfile-api-dev
@@ -1,25 +1,10 @@
-# ---------------- Dockerfile-api-dev ----------------
-# ---------- build ----------
 FROM gradle:8.8-jdk17 AS builder
 WORKDIR /usr/src/app
 
 COPY . .
 
-# Docker build context 안에 secret yml/json이 실제로 들어왔는지 검증
-RUN echo "API yml in builder:" && \
-    wc -c api-server/src/main/resources/application-dev.yml && \
-    test -s api-server/src/main/resources/application-dev.yml && \
-    grep -q "jwt:" api-server/src/main/resources/application-dev.yml && \
-    grep -q "secret:" api-server/src/main/resources/application-dev.yml && \
-    echo "API firebase json in builder:" && \
-    wc -c api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json && \
-    test -s api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json && \
-    grep -q '"type"[[:space:]]*:[[:space:]]*"service_account"' api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json && \
-    grep -q '"private_key"' api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-
 RUN chmod +x ./gradlew && ./gradlew :api-server:bootJar -x test
 
-# ---------- runtime ----------
 FROM eclipse-temurin:17-jdk
 
 RUN apt-get update && \
@@ -30,22 +15,6 @@ ENV TZ=Asia/Seoul
 ENV JAVA_TOOL_OPTIONS="-Duser.timezone=Asia/Seoul -Xms128m -Xmx384m"
 
 WORKDIR /app
-
-# runtime에도 secret yml/json 복사
-COPY api-server/src/main/resources/application-dev.yml /app/application-dev.yml
-COPY api-server/src/main/resources/firebase/napzak-firebase-adminsdk.json /app/firebase/napzak-firebase-adminsdk.json
-
-# runtime 파일도 0바이트면 이미지 빌드 실패
-RUN echo "API yml in runtime:" && \
-    wc -c /app/application-dev.yml && \
-    test -s /app/application-dev.yml && \
-    grep -q "jwt:" /app/application-dev.yml && \
-    grep -q "secret:" /app/application-dev.yml && \
-    echo "API firebase json in runtime:" && \
-    wc -c /app/firebase/napzak-firebase-adminsdk.json && \
-    test -s /app/firebase/napzak-firebase-adminsdk.json && \
-    grep -q '"type"[[:space:]]*:[[:space:]]*"service_account"' /app/firebase/napzak-firebase-adminsdk.json && \
-    grep -q '"private_key"' /app/firebase/napzak-firebase-adminsdk.json
 
 COPY --from=builder /usr/src/app/api-server/build/libs/api-server.jar /app/api-server.jar
 

--- a/Dockerfile-chat-dev
+++ b/Dockerfile-chat-dev
@@ -5,12 +5,17 @@ WORKDIR /usr/src/app
 
 COPY . .
 
-# ✅ Docker build context 안에 secret yml이 실제로 들어왔는지 검증
+# Docker build context 안에 secret yml/json이 실제로 들어왔는지 검증
 RUN echo "CHAT yml in builder:" && \
     wc -c chat-server/src/main/resources/application-dev.yml && \
     test -s chat-server/src/main/resources/application-dev.yml && \
     grep -q "jwt:" chat-server/src/main/resources/application-dev.yml && \
-    grep -q "secret:" chat-server/src/main/resources/application-dev.yml
+    grep -q "secret:" chat-server/src/main/resources/application-dev.yml && \
+    echo "CHAT firebase json in builder:" && \
+    wc -c chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json && \
+    test -s chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json && \
+    grep -q '"type"[[:space:]]*:[[:space:]]*"service_account"' chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json && \
+    grep -q '"private_key"' chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
 
 RUN chmod +x ./gradlew && ./gradlew :chat-server:bootJar -x test
 
@@ -26,16 +31,21 @@ ENV JAVA_TOOL_OPTIONS="-Duser.timezone=Asia/Seoul -Xms128m -Xmx384m"
 
 WORKDIR /app
 
-# ✅ runtime에도 secret yml 복사
+# runtime에도 secret yml/json 복사
 COPY chat-server/src/main/resources/application-dev.yml /app/application-dev.yml
 COPY chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json /app/firebase/napzak-firebase-adminsdk.json
 
-# ✅ runtime 파일도 0바이트면 이미지 빌드 실패
+# runtime 파일도 0바이트면 이미지 빌드 실패
 RUN echo "CHAT yml in runtime:" && \
     wc -c /app/application-dev.yml && \
     test -s /app/application-dev.yml && \
     grep -q "jwt:" /app/application-dev.yml && \
-    grep -q "secret:" /app/application-dev.yml
+    grep -q "secret:" /app/application-dev.yml && \
+    echo "CHAT firebase json in runtime:" && \
+    wc -c /app/firebase/napzak-firebase-adminsdk.json && \
+    test -s /app/firebase/napzak-firebase-adminsdk.json && \
+    grep -q '"type"[[:space:]]*:[[:space:]]*"service_account"' /app/firebase/napzak-firebase-adminsdk.json && \
+    grep -q '"private_key"' /app/firebase/napzak-firebase-adminsdk.json
 
 COPY --from=builder /usr/src/app/chat-server/build/libs/chat-server.jar /app/chat-server.jar
 

--- a/Dockerfile-chat-dev
+++ b/Dockerfile-chat-dev
@@ -1,25 +1,10 @@
-# ---------------- Dockerfile-chat-dev ----------------
-# ---------- build ----------
 FROM gradle:8.8-jdk17 AS builder
 WORKDIR /usr/src/app
 
 COPY . .
 
-# Docker build context 안에 secret yml/json이 실제로 들어왔는지 검증
-RUN echo "CHAT yml in builder:" && \
-    wc -c chat-server/src/main/resources/application-dev.yml && \
-    test -s chat-server/src/main/resources/application-dev.yml && \
-    grep -q "jwt:" chat-server/src/main/resources/application-dev.yml && \
-    grep -q "secret:" chat-server/src/main/resources/application-dev.yml && \
-    echo "CHAT firebase json in builder:" && \
-    wc -c chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json && \
-    test -s chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json && \
-    grep -q '"type"[[:space:]]*:[[:space:]]*"service_account"' chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json && \
-    grep -q '"private_key"' chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json
-
 RUN chmod +x ./gradlew && ./gradlew :chat-server:bootJar -x test
 
-# ---------- runtime ----------
 FROM eclipse-temurin:17-jdk
 
 RUN apt-get update && \
@@ -30,22 +15,6 @@ ENV TZ=Asia/Seoul
 ENV JAVA_TOOL_OPTIONS="-Duser.timezone=Asia/Seoul -Xms128m -Xmx384m"
 
 WORKDIR /app
-
-# runtime에도 secret yml/json 복사
-COPY chat-server/src/main/resources/application-dev.yml /app/application-dev.yml
-COPY chat-server/src/main/resources/firebase/napzak-firebase-adminsdk.json /app/firebase/napzak-firebase-adminsdk.json
-
-# runtime 파일도 0바이트면 이미지 빌드 실패
-RUN echo "CHAT yml in runtime:" && \
-    wc -c /app/application-dev.yml && \
-    test -s /app/application-dev.yml && \
-    grep -q "jwt:" /app/application-dev.yml && \
-    grep -q "secret:" /app/application-dev.yml && \
-    echo "CHAT firebase json in runtime:" && \
-    wc -c /app/firebase/napzak-firebase-adminsdk.json && \
-    test -s /app/firebase/napzak-firebase-adminsdk.json && \
-    grep -q '"type"[[:space:]]*:[[:space:]]*"service_account"' /app/firebase/napzak-firebase-adminsdk.json && \
-    grep -q '"private_key"' /app/firebase/napzak-firebase-adminsdk.json
 
 COPY --from=builder /usr/src/app/chat-server/build/libs/chat-server.jar /app/chat-server.jar
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,4 +1,3 @@
-# docker-compose-dev.yml
 services:
   api-server:
     image: 203918864903.dkr.ecr.ap-northeast-2.amazonaws.com/napzak-api-dev:latest
@@ -8,6 +7,11 @@ services:
     depends_on:
       redis: { condition: service_healthy }
       rabbitmq: { condition: service_healthy }
+    environment:
+      FIREBASE_CONFIG_PATH: file:/app/firebase/napzak-firebase-adminsdk.json
+    volumes:
+      - ./secrets/api/application-dev.yml:/app/application-dev.yml:ro
+      - ./secrets/api/napzak-firebase-adminsdk.json:/app/firebase/napzak-firebase-adminsdk.json:ro
     networks: [napzak-dev-net]
 
   chat-server:
@@ -18,6 +22,11 @@ services:
     depends_on:
       redis: { condition: service_healthy }
       rabbitmq: { condition: service_healthy }
+    environment:
+      FIREBASE_CONFIG_PATH: file:/app/firebase/napzak-firebase-adminsdk.json
+    volumes:
+      - ./secrets/chat/application-dev.yml:/app/application-dev.yml:ro
+      - ./secrets/chat/napzak-firebase-adminsdk.json:/app/firebase/napzak-firebase-adminsdk.json:ro
     networks: [napzak-dev-net]
 
   redis:


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #285 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
## 작업 내용

* PR CI에서 실제 dev secret을 주입하지 않고 dummy `application-dev.yml` 및 dummy Firebase credential을 생성하도록 변경했습니다.
* Docker build 단계에서 실제 `application-dev.yml`과 Firebase Admin SDK JSON을 사용하지 않도록 수정했습니다.
* Docker runtime image에 `application-dev.yml`과 Firebase service account JSON이 포함되지 않도록 Dockerfile의 secret 파일 COPY를 제거했습니다.
* 실제 dev secret은 push/CD의 deploy 단계에서만 EC2의 `secrets/` 디렉토리에 runtime 파일로 생성되도록 변경했습니다.
* Firebase Admin SDK JSON은 기존 raw JSON secret 주입 방식에서 base64 GitHub Secret을 decode하는 방식으로 변경했습니다.
* `API_FIREBASE_JSON_BASE64`, `CHAT_FIREBASE_JSON_BASE64` secret을 사용하도록 dev CD workflow를 수정했습니다.
* `docker-compose-dev.yml`에서 runtime secret 파일을 read-only volume으로 mount하도록 변경했습니다.
* `FIREBASE_CONFIG_PATH=file:/app/firebase/napzak-firebase-adminsdk.json` 환경변수를 통해 runtime Firebase credential 경로를 override하도록 설정했습니다.
* Spring Boot 실행 시 `/app/application-dev.yml`을 명시적으로 로딩하도록 `spring.config.additional-location` 옵션을 유지했습니다.
* deploy 단계에서 `application-dev.yml` 파일 존재 여부, `jwt.secret` 존재 여부, Firebase JSON syntax 및 필수 필드(`type`, `project_id`, `private_key`, `client_email`)를 검증하도록 추가했습니다.
* EC2 runtime secret 디렉토리가 Git에 포함되지 않도록 `secrets/`를 `.gitignore`에 추가했습니다.

## 배경

dev 서버에서 API/Chat 컨테이너가 기동 중 `jwt.secret` placeholder 오류와 FirebaseMessaging 초기화 실패가 발생했습니다. 확인 결과 기존 배포 구조에서는 `application-dev.yml` 또는 Firebase Admin SDK JSON이 정상적으로 주입되지 않거나, Firebase JSON이 올바른 JSON 형식으로 생성되지 않아 `MalformedJsonException`이 발생할 수 있었습니다.

초기에는 CI/CD와 Docker build 과정에서 실제 secret 파일을 생성하고 이미지 내부에 포함하는 방식으로 문제를 해결하려 했지만, 이 구조는 PR CI에서 dev secret이 workspace에 노출될 수 있고, ECR image를 pull/export할 수 있는 주체가 image layer에서 Firebase private key와 JWT secret을 획득할 수 있는 보안 위험이 있었습니다.

이를 개선하기 위해 PR CI에서는 dummy config만 사용하고, 실제 dev secret은 CD deploy 단계에서만 EC2 runtime 파일로 생성되도록 변경했습니다. 또한 Docker image에는 secret 파일을 포함하지 않고, docker-compose volume mount를 통해 실행 시점에만 주입되도록 수정했습니다.

## 확인 방법

* PR CI에서 실제 GitHub dev secret 없이 Gradle build가 통과하는지 확인합니다.
* dev-CD build-push 단계에서 secret 파일 생성 없이 Docker image build/push가 성공하는지 확인합니다.
* deploy 단계에서 다음 검증이 통과하는지 확인합니다.

  * `application-dev.yml` 파일 존재 여부
  * `jwt.secret` 존재 여부
  * Firebase JSON syntax 검증
  * Firebase JSON 필수 필드 검증
* 배포 후 EC2에서 API/Chat 컨테이너가 정상 기동되는지 확인합니다.
* API/Chat 컨테이너 로그에서 기존 `jwt.secret` placeholder 오류와 Firebase JSON parsing 오류가 재발하지 않는지 확인합니다.
* 컨테이너 내부에서 `/app/application-dev.yml`, `/app/firebase/napzak-firebase-adminsdk.json`이 read-only volume으로 mount되었는지 확인합니다.

## 보안상 변경점

* 실제 dev secret을 PR CI에서 사용하지 않습니다.
* 실제 dev secret을 Docker build 단계에서 사용하지 않습니다.
* Firebase private key와 JWT secret을 Docker image에 포함하지 않습니다.
* Firebase private key와 JWT secret은 EC2 runtime 파일로만 주입됩니다.
* runtime secret 파일은 read-only volume으로 컨테이너에 mount됩니다.
* EC2에 생성되는 `secrets/` 디렉토리는 Git tracking 대상에서 제외됩니다.

## 참고 사항

* 기존 `FirebaseConfig`는 `classpath:`와 `file:` 경로를 모두 지원하고 있어 Java 코드는 변경하지 않았습니다.
* 기존 `API_FIREBASE_JSON`, `CHAT_FIREBASE_JSON` raw JSON secret은 더 이상 사용하지 않습니다.
* 배포 성공 후 기존 ECR image에 secret이 포함되었을 가능성을 고려해 Firebase service account key rotation을 권장합니다.


## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 파이프라인의 설정 파일 및 보안 인증서 검증 절차 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->